### PR TITLE
LineageOS not working for Samsung Galaxy S6 bootloader version G920FXXS5ERA7 

### DIFF
--- a/configs/audio/mixer_paths_0.xml
+++ b/configs/audio/mixer_paths_0.xml
@@ -1,0 +1,4895 @@
+<mixer>
+    <!-- ########## Initial mixer settings ########## -->
+
+	<pcmdai playback_link="6" />
+	<pcmdai playback_jam_link="7" />
+	<pcmdai playback_deep_link="3" />
+	<pcmdai capture_link="0" />
+	<pcmdai baseband_link="1" />
+	<pcmdai bluetooth_link="2" />
+
+	<!-- Reset configurations -->
+	<ctl name="IN1L Mux" value="A" />
+	<ctl name="IN2L Mux" value="B" />
+	<ctl name="HP Switch" value="0" />
+	<ctl name="SPK Switch" value="0" />
+	<ctl name="RCV Switch" value="0" />
+	<ctl name="Main Mic Switch" value="0" />
+	<ctl name="Sub Mic Switch" value="0" />
+	<ctl name="Third Mic Switch" value="0" />
+	<ctl name="Headset Mic Switch" value="0" />
+	<ctl name="VI SENSING Switch" value="0" />
+	<ctl name="FM In Switch" value="0" />
+	<ctl name="AIF2 Mode" value="Slave" />
+	<ctl name="CP Mode" value="Default" />
+	<ctl name="VoiceControl Mode" value="Normal" />
+	<ctl name="Noise Gate Switch" value="0" />
+	<ctl name="HPOUT1 Digital Switch" value="1" />
+	<ctl name="HPOUT3 Digital Switch" value="1" />
+	<ctl name="SPK Enable Switch" value="Enable" />
+
+	<ctl name="HPOUT1 DRE Switch" value="0" />
+	<ctl name="HPOUT3 DRE Switch" value="0" />
+	<ctl name="HPOUT1 EDRE Switch" value="0" />
+	<ctl name="HPOUT3 EDRE Switch" value="0" />
+
+	<ctl name="IN1 OSR" value="1.536MHz" />
+	<ctl name="IN3 OSR" value="1.536MHz" />
+
+	<ctl name="IN1L HPF Switch" value="1" />
+	<ctl name="IN3L HPF Switch" value="1" />
+	<ctl name="Input Ramp Up" value="8ms/6dB" />
+
+	<!-- default routes -->
+	<ctl name="Sample Rate 2" value="16kHz" />
+	<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+	<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+	<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+
+	<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+	<ctl name="ASRC1 Rate 2" value="ASYNCCLK rate" />
+	<ctl name="ASRC2 Rate 1" value="SYNCCLK rate 1" />
+	<ctl name="ASRC2 Rate 2" value="ASYNCCLK rate 2" />
+
+	<ctl name="HPOUT1L Input 1" value="AIF1RX1" />
+	<ctl name="HPOUT1R Input 1" value="AIF1RX2" />
+	<ctl name="HPOUT3L Input 1" value="AIF1RX1" />
+	<ctl name="HPOUT3R Input 1" value="AIF1RX2" />
+	<ctl name="HPOUT3L Input 2" value="ISRC2INT1" />
+	<ctl name="HPOUT3R Input 2" value="ISRC2INT1" />
+	<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+	<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+	<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+	<ctl name="ASRC1IN2R Input" value="AIF2RX2" />
+
+	<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+	<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+	<ctl name="ISRC2DEC1 Input" value="IN1L" />
+	<ctl name="ISRC2DEC2 Input" value="IN3L" />
+
+	<ctl name="ISRC4 FSL" value="SYNCCLK rate 3" />
+	<ctl name="ISRC4 FSH" value="SYNCCLK rate 1" />
+	<ctl name="ISRC4DEC1 Input" value="DSP5.1" />
+	<ctl name="ISRC4DEC2 Input" value="DSP5.1" />
+	<ctl name="ISRC4INT1 Input" value="AIF4RX1" />
+	<ctl name="ISRC4INT2 Input" value="AIF4RX2" />		
+
+	<ctl name="DSP5 Aux 2" value="ISRC4INT1" />
+	<ctl name="DSP5 Aux 3" value="ISRC4INT2" />
+	<ctl name="DSP5L Input 1" value="AIF1RX1" />
+	<ctl name="DSP5L Input 2" value="AIF1RX2" />
+
+	<!-- default routes for earphone tuning -->
+	<ctl name="HPOUT1L ONEFLT Switch" value="1" />
+	<ctl name="HPOUT1R ONEFLT Switch" value="1" />
+	<ctl name="DAC COMP 1" value="5 14" />
+	<ctl name="DAC COMP 2" value="1 1" />
+	<ctl name="FRF COEFF 1L" value="3 244 247 48 6 4 254 205" />
+	<ctl name="FRF COEFF 1R" value="3 244 247 48 6 4 254 205" />
+
+	<!-- EQs Filter setting -->
+	<ctl name="EQ1 Coefficients" value="0 0 15 209 3 253 0 188 30 244 241 7 4 12 4 18 29 30 242 193 4 10 10 232 24 73 246 214 4 10 27 18 6 216 5 182 64 0 0 0" />
+	<ctl name="EQ1 B1 Volume" value="12" />
+	<ctl name="EQ1 B2 Volume" value="12" />
+	<ctl name="EQ1 B3 Volume" value="12" />
+	<ctl name="EQ1 B4 Volume" value="12" />
+	<ctl name="EQ1 B5 Volume" value="12" />
+	<ctl name="EQ2 Coefficients" value="0 0 14 252 3 255 4 16 20 219 249 109 4 10 37 84 25 146 242 231 4 10 11 127 19 112 248 160 4 10 34 40 6 161 5 168 64 0 0 0" />
+	<ctl name="EQ2 B1 Volume" value="12" />
+	<ctl name="EQ2 B2 Volume" value="12" />
+	<ctl name="EQ2 B3 Volume" value="7" />
+	<ctl name="EQ2 B4 Volume" value="8" />
+	<ctl name="EQ2 B5 Volume" value="12" />
+	<ctl name="EQ3 Coefficients" value="0 0 14 252 3 255 4 16 22 148 248 40 4 10 32 77 25 146 242 231 4 10 11 127 18 140 249 19 4 10 35 240 6 161 5 168 64 0 0 0 " />
+	<ctl name="EQ3 B1 Volume" value="12" />
+	<ctl name="EQ3 B2 Volume" value="12" />
+	<ctl name="EQ3 B3 Volume" value="12" />
+	<ctl name="EQ3 B4 Volume" value="7" />
+	<ctl name="EQ3 B5 Volume" value="7" />
+	<ctl name="EQ4 Coefficients" value="0 0 15 209 3 253 0 188 30 244 241 7 4 12 4 18 29 30 242 193 4 10 10 232 24 73 246 214 4 10 27 18 6 216 5 182 64 0 0 0" />
+	<ctl name="EQ4 B1 Volume" value="12" />
+	<ctl name="EQ4 B2 Volume" value="12" />
+	<ctl name="EQ4 B3 Volume" value="12" />
+	<ctl name="EQ4 B4 Volume" value="12" />
+	<ctl name="EQ4 B5 Volume" value="12" />
+
+	<!-- Channel information -->
+	<!-- main_mic : Left -->
+	<!-- 2nd_mic : Right -->
+	<!-- headset_mic : Right -->
+	<!-- 3rd_mic : Right -->
+	<!-- sco : None -->
+	<path name="capture_channel_left">
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<path name="capture_channel_right">
+		<ctl name="AIF1TX1 Input 1" value="LHPF2" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF2" />
+	</path>
+
+	<path name="capture_channel_stereo">
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF2" />
+	</path>
+
+	<path name="capture_channel_invert">
+		<ctl name="AIF1TX1 Input 1" value="LHPF2" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<!-- call volume index -->
+	<path name="call_nb_volume_index">
+		<param name="DSP4 XM f010:1" id="295" />
+	</path>
+
+	<path name="call_wb_volume_index">
+		<param name="DSP4 XM f011:1" id="295" />
+	</path>
+
+	<path name="mute-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="0" />
+		<ctl name="DSP5L Input 2 Volume" value="0" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="0" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="0" />
+	</path>
+
+	<path name="unmute-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="mute-headset">
+		<ctl name="HP Switch" value="0" />
+	</path>
+
+	<path name="default-impedance-volume">
+		<ctl name="HPOUT1L Impedance Volume" value="114" />
+		<ctl name="HPOUT1R Impedance Volume" value="114" />
+	</path>
+
+	<!-- Output stage -->
+	<!-- media playback -->
+	<path name="media-handset">
+		<ctl name="CP Mode" value="Inverting" />
+		<ctl name="HPOUT3L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT3R Input 1" value="AIF1RX2" />
+		<ctl name="RCV Switch" value="1" />
+	</path>
+
+	<path name="media-speaker">
+		<ctl name="Sample Rate 3" value="48kHz" />
+		<ctl name="ISRC4 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC4 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP5 Rate" value="SYNCCLK rate 1" />
+		<ctl name="DSP5L Input 1" value="AIF1RX1" />
+		<ctl name="DSP5L Input 2" value="AIF1RX2" />
+		<ctl name="ISRC4DEC1 Input" value="DSP5.1" />
+		<ctl name="ISRC4DEC2 Input" value="DSP5.1" />
+		<ctl name="AIF4TX1 Input 1" value="ISRC4DEC1" />
+		<ctl name="AIF4TX2 Input 1" value="ISRC4DEC2" />
+		<ctl name="ISRC4INT1 Input" value="AIF4RX1" />
+		<ctl name="ISRC4INT2 Input" value="AIF4RX2" />
+		<ctl name="DSP5 Aux 2" value="ISRC4INT1" />
+		<ctl name="DSP5 Aux 3" value="ISRC4INT2" />
+		<ctl name="VI SENSING Switch" value="1" />
+		<ctl name="SPK Switch" value="1" />
+	</path>
+
+	<path name="media-headset">
+		<path name="mute-speaker" />
+		<ctl name="HPOUT1 DRE Switch" value="1" />
+		<ctl name="HPOUT1 EDRE Switch" value="1" />
+		<ctl name="HPOUT1L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT1R Input 1" value="AIF1RX2" />
+		<ctl name="HP Switch" value="1" />
+	</path>
+
+	<path name="media-speaker-headset">
+		<path name="media-speaker" />
+		<path name="media-headset" />
+	</path>
+
+	<path name="media-bt-sco-headset">
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="AIF3TX1 Input 1" value="ISRC2DEC1" />
+		<ctl name="AIF3TX2 Input 1" value="ISRC2DEC2" />
+		<ctl name="ISRC2DEC1 Input" value="AIF1RX1" />
+		<ctl name="ISRC2DEC2 Input" value="AIF1RX2" />
+	</path>
+
+	<path name="media-speaker-bt-sco-headset">
+		<path name="media-bt-sco-headset" />
+		<path name="media-speaker" />
+	</path>
+
+	<!-- Ringtone playback -->
+	<path name="ringtone-handset">
+		<path name="media-handset" />
+	</path>
+
+	<path name="ringtone-speaker">
+		<path name="media-speaker" />
+	</path>
+
+	<path name="ringtone-headset">
+		<path name="media-headset" />
+	</path>
+
+	<path name="ringtone-speaker-headset">
+		<path name="media-speaker-headset" />
+	</path>
+
+	<path name="ringtone-bt-sco-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<path name="ringtone-speaker-bt-sco-headset">
+		<path name="media-speaker-bt-sco-headset" />
+	</path>
+
+	<!-- Communication playback -->
+	<path name="communication-handset">
+		<path name="media-handset" />
+	</path>
+
+	<path name="communication-speaker">
+		<ctl name="AIF4TX1 Input 1" value="AIF1RX1" />
+		<ctl name="AIF4TX2 Input 1" value="AIF1RX2" />
+		<ctl name="SPK Switch" value="1" />
+	</path>
+
+	<path name="communication-headset">
+		<ctl name="HPOUT1L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT1R Input 1" value="AIF1RX2" />
+		<ctl name="HP Switch" value="1" />
+	</path>
+
+	<path name="communication-headphone">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="communication-bt-sco-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<path name="communication-bt-ble-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<!-- samsung voip playback -->
+	<path name="samsung_voip-handset">
+		<path name="media-handset" />
+	</path>
+
+	<path name="samsung_voip-speaker">
+		<path name="communication-speaker" />
+	</path>
+
+	<path name="samsung_voip-headset">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="samsung_voip-headphone">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="samsung_voip-bt-sco-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<path name="samsung_voip-bt-ble-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<!-- voip playback -->
+	<path name="voip-handset">
+		<path name="media-handset" />
+	</path>
+
+	<path name="voip-speaker">
+		<path name="communication-speaker" />
+	</path>
+
+	<path name="voip-headset">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="voip-headphone">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="voip-bt-sco-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<path name="voip-bt-ble-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<!-- wificall playback -->
+	<!-- wificall AP NB -->
+	<path name="wificall_nb-handset">
+		<path name="mute-headset" />
+		<path name="mute-speaker" />
+		<ctl name="CP Mode" value="Inverting" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP4 Firmware" value="RX_NB" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="DSP4 Aux 1" value="ISRC2DEC3" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC1" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="HPOUT3L Input 1" value="ISRC2INT1" />
+		<ctl name="HPOUT3R Input 1" value="ISRC2INT1" />
+		<ctl name="HPOUT3L Input 2" value="None" />
+		<ctl name="HPOUT3R Input 2" value="None" />
+		<ctl name="RCV Switch" value="1" />
+	</path>
+
+	<path name="wificall_nb-speaker">
+		<path name="mute-headset" />
+		<path name="unmute-speaker" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP5 Rate" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP4 Firmware" value="RX_NB" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="DSP4 Aux 1" value="ISRC2DEC3" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC2" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="DSP5L Input 1" value="ISRC2INT1" />
+		<ctl name="DSP5L Input 2" value="ISRC2INT1" />
+		<ctl name="AIF4TX1 Input 1" value="DSP5.1" />
+		<ctl name="AIF4TX2 Input 1" value="DSP5.1" />
+		<ctl name="DSP5 Aux 2" value="AIF4RX1" />
+		<ctl name="DSP5 Aux 3" value="AIF4RX2" />
+		<ctl name="VI SENSING Switch" value="1" />
+		<ctl name="SPK Switch" value="1" />
+	</path>
+
+	<path name="wificall_nb-headset">
+		<path name="default-impedance-volume" />
+		<path name="mute-speaker" />
+		<path name="communication-headset" />
+	</path>
+
+	<path name="wificall_nb-headphone">
+		<path name="default-impedance-volume" />
+		<path name="mute-speaker" />
+		<path name="communication-headset" />
+	</path>
+
+	<path name="wificall_nb-bt-sco-headset">
+		<path name="mute-headset" />
+		<path name="media-bt-sco-headset" />
+	</path>
+	
+	<path name="wificall_nb-bt-ble-headset">
+		<path name="mute-headset" />
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<!-- wificall NB/EXTRA_VOL -->
+	<path name="wificall_nb_extra_vol-handset">
+		<path name="wificall_nb-handset" />
+	</path>
+
+	<path name="wificall_nb_extra_vol-speaker">
+		<path name="wificall_nb-speaker" />
+	</path>
+
+	<!-- wificall AP WB -->
+	<path name="wificall_wb-handset">
+		<path name="mute-headset" />
+		<path name="mute-speaker" />
+		<ctl name="CP Mode" value="Inverting" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP4 Firmware" value="RX_WB" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="DSP4 Aux 1" value="ISRC2DEC3" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC1" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="HPOUT3L Input 1" value="ISRC2INT1" />
+		<ctl name="HPOUT3R Input 1" value="ISRC2INT1" />
+		<ctl name="HPOUT3L Input 2" value="None" />
+		<ctl name="HPOUT3R Input 2" value="None" />
+		<ctl name="RCV Switch" value="1" />
+	</path>
+
+	<path name="wificall_wb-speaker">
+		<path name="mute-headset" />
+		<path name="unmute-speaker" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP5 Rate" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP4 Firmware" value="RX_WB" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="DSP4 Aux 1" value="ISRC2DEC3" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC2" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="DSP5L Input 1" value="ISRC2INT1" />
+		<ctl name="DSP5L Input 2" value="ISRC2INT1" />
+		<ctl name="AIF4TX1 Input 1" value="DSP5.1" />
+		<ctl name="AIF4TX2 Input 1" value="DSP5.1" />
+		<ctl name="DSP5 Aux 2" value="AIF4RX1" />
+		<ctl name="DSP5 Aux 3" value="AIF4RX2" />
+		<ctl name="VI SENSING Switch" value="1" />
+		<ctl name="SPK Switch" value="1" />
+	</path>
+
+	<path name="wificall_wb-headset">
+		<path name="default-impedance-volume" />
+		<path name="mute-speaker" />
+		<path name="communication-headset" />
+	</path>
+
+	<path name="wificall_wb-headphone">
+		<path name="default-impedance-volume" />
+		<path name="mute-speaker" />
+		<path name="communication-headset" />
+	</path>
+
+	<path name="wificall_wb-bt-sco-headset">
+		<path name="mute-headset" />
+		<path name="media-bt-sco-headset" />
+	</path>
+	
+	<path name="wificall_wb-bt-ble-headset">
+		<path name="mute-headset" />
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<!-- wificall WB/EXTRA_VOL -->
+	<path name="wificall_wb_extra_vol-handset">
+		<path name="wificall_wb-handset" />
+	</path>
+
+	<path name="wificall_wb_extra_vol-speaker">
+		<path name="wificall_wb-speaker" />
+	</path>
+
+	<!-- Video call playback -->
+	<path name="video_call-handset">
+		<path name="mute-headset" />
+		<path name="mute-speaker" />
+		<ctl name="CP Mode" value="Inverting" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP4 Firmware" value="RX_NB" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="DSP4 Aux 1" value="ISRC2DEC3" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC1" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="HPOUT3L Input 1" value="ISRC2INT1" />
+		<ctl name="HPOUT3R Input 1" value="ISRC2INT1" />
+		<ctl name="RCV Switch" value="1" />
+	</path>
+
+	<path name="video_call-speaker">
+		<path name="mute-headset" />
+		<path name="unmute-speaker" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP5 Rate" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP4 Firmware" value="RX_NB" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="DSP4 Aux 1" value="ISRC2DEC3" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC2" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="DSP5L Input 1" value="ISRC2INT1" />
+		<ctl name="DSP5L Input 2" value="ISRC2INT1" />
+		<ctl name="AIF4TX1 Input 1" value="DSP5.1" />
+		<ctl name="AIF4TX2 Input 1" value="DSP5.1" />
+		<ctl name="DSP5 Aux 2" value="AIF4RX1" />
+		<ctl name="DSP5 Aux 3" value="AIF4RX2" />
+		<ctl name="VI SENSING Switch" value="1" />
+		<ctl name="SPK Switch" value="1" />
+	</path>
+
+	<path name="video_call-headset">
+		<path name="mute-speaker" />
+		<path name="communication-headset" />
+	</path>
+
+	<path name="video_call-headphone">
+		<path name="mute-speaker" />
+		<path name="communication-headset" />
+	</path>
+
+	<path name="video_call-bt-sco-headset">
+		<path name="mute-headset" />
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<path name="video_call-bt-ble-headset">
+		<path name="mute-headset" />
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<!-- VoLTE AP playback -->
+	<!-- VoLTE AP NB -->
+	<path name="volte_vt_ap_nb-handset">
+		<path name="media-handset" />
+	</path>
+
+	<path name="volte_vt_ap_nb-speaker">
+		<path name="communication-speaker" />
+	</path>
+
+	<path name="volte_vt_ap_nb-headset">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="volte_vt_ap_nb-headphone">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="volte_vt_ap_nb-bt-sco-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<path name="volte_vt_ap_nb-bt-ble-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<!-- VoLTE AP WB -->
+	<path name="volte_vt_ap_wb-handset">
+		<path name="media-handset" />
+	</path>
+
+	<path name="volte_vt_ap_wb-speaker">
+		<path name="communication-speaker" />
+	</path>
+
+	<path name="volte_vt_ap_wb-headset">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="volte_vt_ap_wb-headphone">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="volte_vt_ap_wb-bt-sco-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<path name="volte_vt_ap_wb-bt-ble-headset">
+		<path name="media-bt-sco-headset" />
+	</path>
+
+	<!-- CP Call Output -->
+	<!-- Default -->
+	<path name="incall_default-handset">
+		<ctl name="CP Mode" value="Inverting" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ISRC2INT3 Input" value="ASRC1IN2L" />
+		<ctl name="HPOUT3L Input 3 Volume" value="0" />
+		<ctl name="HPOUT3R Input 3 Volume" value="0" />
+		<ctl name="HPOUT3L Input 3" value="ISRC2INT3" />
+		<ctl name="HPOUT3R Input 3" value="ISRC2INT3" />
+		<ctl name="HPOUT3L Input 3 Volume" value="32" />
+		<ctl name="HPOUT3R Input 3 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2" value="None" />
+		<ctl name="HPOUT3R Input 2" value="None" />
+		<!-- default volume -->
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT3R Input 1" value="AIF1RX2" />
+		<ctl name="RCV Switch" value="1" />
+	</path>
+
+	<path name="incall_default-speaker">
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP5 Rate" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ISRC2INT3 Input" value="ASRC1IN2L" />
+		<ctl name="LHPF4 Input 1" value="AIF1RX1" />
+		<ctl name="LHPF4 Input 3 Volume" value="0" />
+		<ctl name="LHPF4 Input 3" value="ISRC2INT3" />
+		<ctl name="LHPF4 Input 3 Volume" value="32" />
+		<ctl name="LHPF4 Input 2" value="None" />
+		<ctl name="DSP5L Input 1" value="LHPF4" />
+		<ctl name="DSP5L Input 2" value="LHPF4" />
+		<ctl name="AIF4TX1 Input 1" value="DSP5.1" />
+		<ctl name="AIF4TX2 Input 1" value="DSP5.1" />
+		<ctl name="DSP5 Aux 2" value="AIF4RX1" />
+		<ctl name="DSP5 Aux 3" value="AIF4RX2" />
+		<ctl name="VI SENSING Switch" value="1" />
+		<ctl name="SPK Switch" value="1" />
+		<!-- default volume -->
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="incall_default-headset">
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="HPOUT1L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT1R Input 1" value="AIF1RX2" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ASRC1IN2R Input" value="AIF2RX1" />
+		<ctl name="HPOUT1L Input 2" value="ASRC1IN2L" />
+		<ctl name="HPOUT1R Input 2" value="ASRC1IN2L" />
+		<ctl name="HP Switch" value="1" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ASRC1IN2L" />
+		<ctl name="AIF1TX2 Input 2" value="ASRC1IN2L" />
+		<!-- default volume -->
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="incall_default-headphone">
+		<path name="incall_default-headset" />
+	</path>
+
+	<path name="incall_default-bt-sco-headset">
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="AIF3TX1 Input 1" value="ISRC2DEC3" />
+		<ctl name="AIF3TX2 Input 1" value="ISRC2DEC4" />
+		<ctl name="AIF3TX1 Input 2" value="ISRC2DEC1" />
+		<ctl name="AIF3TX2 Input 2" value="ISRC2DEC2" />
+		<ctl name="ISRC2DEC1 Input" value="ASRC1IN2L" />
+		<ctl name="ISRC2DEC2 Input" value="ASRC1IN2R" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="ISRC2DEC4 Input" value="AIF1RX2" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ASRC1IN2R Input" value="AIF2RX2" />
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<path name="incall_default-bt-ble-headset">
+		<path name="incall_default-bt-sco-headset" />
+	</path>
+
+	<!-- NB -->
+	<path name="incall_nb-handset">
+		<path name="mute-headset" />
+		<path name="mute-speaker" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="CP Mode" value="Inverting" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="DSP4 Firmware" value="RX_NB" />
+		<ctl name="DSP4 Aux 1" value="ASRC1IN2L" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC1" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="HPOUT3L Input 2 Volume" value="0" />
+		<ctl name="HPOUT3R Input 2 Volume" value="0" />
+		<ctl name="HPOUT3L Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT3R Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<ctl name="HPOUT3L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT3R Input 1" value="AIF1RX2" />
+		<ctl name="RCV Switch" value="1" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 2" value="ISRC2INT1" />
+	</path>
+
+	<path name="incall_nb-speaker">
+		<path name="mute-headset" />
+		<path name="unmute-speaker" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP5 Rate" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="DSP4 Firmware" value="RX_NB" />
+		<ctl name="DSP4 Aux 1" value="ASRC1IN2L" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC2" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="LHPF4 Input 1" value="AIF1RX1" />
+		<ctl name="LHPF4 Input 2 Volume" value="0" />
+		<ctl name="LHPF4 Input 2" value="ISRC2INT1" />
+		<ctl name="LHPF4 Input 2 Volume" value="32" />
+		<ctl name="DSP5L Input 1" value="LHPF4" />
+		<ctl name="DSP5L Input 2" value="LHPF4" />
+		<ctl name="AIF4TX1 Input 1" value="DSP5.1" />
+		<ctl name="AIF4TX2 Input 1" value="DSP5.1" />
+		<ctl name="DSP5 Aux 2" value="AIF4RX1" />
+		<ctl name="DSP5 Aux 3" value="AIF4RX2" />
+		<ctl name="VI SENSING Switch" value="1" />
+		<ctl name="SPK Switch" value="1" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 2" value="ISRC2INT1" />
+	</path>
+
+	<path name="incall_nb-headset">
+		<path name="mute-speaker" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ASRC1IN2R Input" value="AIF2RX1" />
+		<ctl name="HPOUT1L Input 2" value="ASRC1IN2L" />
+		<ctl name="HPOUT1R Input 2" value="ASRC1IN2L" />
+		<ctl name="HPOUT1L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT1R Input 1" value="AIF1RX2" />
+		<ctl name="HP Switch" value="1" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ASRC1IN2L" />
+		<ctl name="AIF1TX2 Input 2" value="ASRC1IN2L" />
+	</path>
+
+	<path name="incall_nb-headphone">
+		<path name="incall_nb-headset" />
+	</path>
+
+	<path name="incall_nb-bt-sco-headset">
+		<path name="mute-headset" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="Sample Rate 2" value="8kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="AIF3TX1 Input 1" value="ISRC2DEC3" />
+		<ctl name="AIF3TX2 Input 1" value="ISRC2DEC4" />
+		<ctl name="AIF3TX1 Input 2" value="ISRC2DEC1" />
+		<ctl name="AIF3TX2 Input 2" value="ISRC2DEC2" />
+		<ctl name="ISRC2DEC1 Input" value="ASRC1IN2L" />
+		<ctl name="ISRC2DEC2 Input" value="ASRC1IN2R" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="ISRC2DEC4 Input" value="AIF1RX2" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ASRC1IN2R Input" value="AIF2RX2" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ASRC1IN2L" />
+		<ctl name="AIF1TX2 Input 2" value="ASRC1IN2R" />
+	</path>
+
+	<path name="incall_nb-bt-ble-headset">
+		<path name="incall_nb-bt-sco-headset" />
+	</path>
+
+	<!-- NB/HANDOVER -->	
+	<path name="incall_nb_handover-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="incall_nb_handover-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<path name="incall_nb_handover-headset">
+		<ctl name="HPOUT1 Digital Switch" value="0" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="DSP4 Firmware" value="RX_NB" />
+		<ctl name="DSP4 Aux 1" value="ASRC1IN2L" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC3" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="HPOUT1L Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT1R Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT1L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT1R Input 1" value="AIF1RX2" />
+		<ctl name="HP Switch" value="1" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT1 Digital Switch" value="1" />
+	</path>
+
+	<path name="incall_nb_handover-headphone">
+		<ctl name="HPOUT1 Digital Switch" value="0" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="DSP4 Firmware" value="RX_NB" />
+		<ctl name="DSP4 Aux 1" value="ASRC1IN2L" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC1" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="HPOUT1L Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT1R Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT1L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT1R Input 1" value="AIF1RX2" />
+		<ctl name="HP Switch" value="1" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT1 Digital Switch" value="1" />
+	</path>
+
+	<!-- NB/EXTRA_VOL -->	
+	<path name="incall_nb_extra_vol-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="incall_nb_extra_vol-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<!-- NB/EXTRA_VOL/HANDOVER -->	
+	<path name="incall_nb_extra_vol_handover-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="incall_nb_extra_vol_handover-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<!-- WB -->
+	<path name="incall_wb-handset">
+		<path name="mute-headset" />
+		<path name="mute-speaker" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="CP Mode" value="Inverting" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="DSP4 Firmware" value="RX_WB" />
+		<ctl name="DSP4 Aux 1" value="ASRC1IN2L" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC1" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="HPOUT3L Input 2 Volume" value="0" />
+		<ctl name="HPOUT3R Input 2 Volume" value="0" />
+		<ctl name="HPOUT3L Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT3R Input 2" value="ISRC2INT1" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<ctl name="HPOUT3L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT3R Input 1" value="AIF1RX2" />
+		<ctl name="RCV Switch" value="1" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 2" value="ISRC2INT1" />
+	</path>
+
+	<path name="incall_wb-speaker">
+		<path name="mute-headset" />
+		<path name="unmute-speaker" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="DSP4 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP5 Rate" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="DSP4 Firmware" value="RX_WB" />
+		<ctl name="DSP4 Aux 1" value="ASRC1IN2L" />
+		<ctl name="DSP4 Aux 2" value="ISRC2DEC2" />
+		<ctl name="ISRC2INT1 Input" value="DSP4.3" />
+		<ctl name="LHPF4 Input 1" value="AIF1RX1" />
+		<ctl name="LHPF4 Input 2 Volume" value="0" />
+		<ctl name="LHPF4 Input 2" value="ISRC2INT1" />
+		<ctl name="LHPF4 Input 2 Volume" value="32" />
+		<ctl name="DSP5L Input 1" value="LHPF4" />
+		<ctl name="DSP5L Input 2" value="LHPF4" />
+		<ctl name="AIF4TX1 Input 1" value="DSP5.1" />
+		<ctl name="AIF4TX2 Input 1" value="DSP5.1" />
+		<ctl name="DSP5 Aux 2" value="AIF4RX1" />
+		<ctl name="DSP5 Aux 3" value="AIF4RX2" />
+		<ctl name="VI SENSING Switch" value="1" />
+		<ctl name="SPK Switch" value="1" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 2" value="ISRC2INT1" />
+	</path>
+
+	<path name="incall_wb-headset">
+		<path name="incall_nb-headset" />
+	</path>
+
+	<path name="incall_wb-headphone">
+		<path name="incall_nb-headphone" />
+	</path>
+
+	<path name="incall_wb-bt-sco-headset">
+		<path name="mute-headset" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="AIF3TX1 Input 1" value="ISRC2DEC3" />
+		<ctl name="AIF3TX2 Input 1" value="ISRC2DEC4" />
+		<ctl name="AIF3TX1 Input 2" value="ISRC2DEC1" />
+		<ctl name="AIF3TX2 Input 2" value="ISRC2DEC2" />
+		<ctl name="ISRC2DEC1 Input" value="ASRC1IN2L" />
+		<ctl name="ISRC2DEC2 Input" value="ASRC1IN2R" />
+		<ctl name="ISRC2DEC3 Input" value="AIF1RX1" />
+		<ctl name="ISRC2DEC4 Input" value="AIF1RX2" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ASRC1IN2R Input" value="AIF2RX2" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 2" value="ASRC1IN2L" />
+		<ctl name="AIF1TX2 Input 2" value="ASRC1IN2R" />
+	</path>
+
+	<path name="incall_wb-bt-ble-headset">
+		<path name="incall_wb-bt-sco-headset" />
+	</path>
+
+	<!-- WB/EXTRA_VOL -->	
+	<path name="incall_wb_extra_vol-handset">
+		<path name="incall_wb-handset" />
+	</path>
+
+	<path name="incall_wb_extra_vol-speaker">
+		<path name="incall_wb-speaker" />
+	</path>
+
+	<!-- VoLTE CP playback -->
+	<!-- VoLTE CP NB -->
+	<path name="volte_cp_nb-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="volte_cp_nb-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<path name="volte_cp_nb-headset">
+		<path name="incall_nb-headset" />
+	</path>
+
+	<path name="volte_cp_nb-headphone">
+		<path name="incall_nb-headphone" />
+	</path>
+
+	<path name="volte_cp_nb-bt-sco-headset">
+		<path name="incall_nb-bt-sco-headset" />
+	</path>
+
+	<path name="volte_cp_nb-bt-ble-headset">
+		<path name="incall_nb-bt-sco-headset" />
+	</path>
+
+	<!-- VoLTE CP NB/HANDOVER -->
+	<path name="volte_cp_nb_handover-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="volte_cp_nb_handover-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<path name="volte_cp_nb_handover-headset">
+		<path name="incall_nb_handover-headset" />
+	</path>
+
+	<path name="volte_cp_nb_handover-headphone">
+		<path name="incall_nb_handover-headphone" />
+	</path>
+
+	<!-- VoLTE CP NB/EXTRA_VOL -->	
+	<path name="volte_cp_nb_extra_vol-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="volte_cp_nb_extra_vol-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<!-- VoLTE CP NB/EXTRA_VOL/HANDOVER -->	
+	<path name="volte_cp_nb_extra_vol_handover-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="volte_cp_nb_extra_vol_handover-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<!-- VoLTE VT CP NB -->
+	<path name="volte_vt_cp_nb-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="volte_vt_cp_nb-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<path name="volte_vt_cp_nb-headset">
+		<path name="incall_nb-headset" />
+	</path>
+
+	<path name="volte_vt_cp_nb-headphone">
+		<path name="incall_nb-headphone" />
+	</path>
+
+	<path name="volte_vt_cp_nb-bt-sco-headset">
+		<path name="incall_nb-bt-sco-headset" />
+	</path>
+
+	<path name="volte_vt_cp_nb-bt-ble-headset">
+		<path name="incall_nb-bt-sco-headset" />
+	</path>
+
+	<!-- VoLTE CP WB -->
+	<path name="volte_cp_wb-handset">
+		<path name="incall_wb-handset" />
+	</path>
+
+	<path name="volte_cp_wb-speaker">
+		<path name="incall_wb-speaker" />
+	</path>
+
+	<path name="volte_cp_wb-headset">
+		<path name="incall_wb-headset" />
+	</path>
+
+	<path name="volte_cp_wb-headphone">
+		<path name="incall_wb-headphone" />
+	</path>
+
+	<path name="volte_cp_wb-bt-sco-headset">
+		<path name="incall_wb-bt-sco-headset" />
+	</path>
+
+	<path name="volte_cp_wb-bt-ble-headset">
+		<path name="incall_wb-bt-sco-headset" />
+	</path>
+
+	<!-- VoLTE CP WB/EXTRA_VOL -->	
+	<path name="volte_cp_wb_extra_vol-handset">
+		<path name="incall_wb-handset" />
+	</path>
+
+	<path name="volte_cp_wb_extra_vol-speaker">
+		<path name="incall_wb-speaker" />
+	</path>
+
+	<!-- VoLTE VT CP WB -->
+	<path name="volte_vt_cp_wb-handset">
+		<path name="incall_wb-handset" />
+	</path>
+
+	<path name="volte_vt_cp_wb-speaker">
+		<path name="incall_wb-speaker" />
+	</path>
+
+	<path name="volte_vt_cp_wb-headset">
+		<path name="incall_wb-headset" />
+	</path>
+
+	<path name="volte_vt_cp_wb-headphone">
+		<path name="incall_wb-headphone" />
+	</path>
+
+	<path name="volte_vt_cp_wb-bt-sco-headset">
+		<path name="incall_wb-bt-sco-headset" />
+	</path>
+
+	<path name="volte_vt_cp_wb-bt-ble-headset">
+		<path name="incall_wb-bt-sco-headset" />
+	</path>
+
+	<!-- Loopback (no delay) -->
+	<path name="loopback-headset">
+		<path name="incall_nb-headset" />
+	</path>
+
+	<!-- Packet Loopback -->
+	<path name="loopback_packet-handset">
+		<path name="incall_nb-handset" />
+	</path>
+
+	<path name="loopback_packet-speaker">
+		<path name="incall_nb-speaker" />
+	</path>
+
+	<path name="loopback_packet-headset">
+		<path name="incall_nb-headset" />
+	</path>
+
+	<!-- TTY Mode -->
+	<path name="tty_mode-handset">
+		<ctl name="CP Mode" value="Inverting" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ASRC1IN2R Input" value="AIF2RX1" />
+		<ctl name="HPOUT3L Input 2" value="ASRC1IN2L" />
+		<ctl name="HPOUT3R Input 2" value="ASRC1IN2R" />
+		<ctl name="HPOUT3L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT3R Input 1" value="AIF1RX2" />
+		<ctl name="RCV Switch" value="1" />
+	</path>
+
+	<path name="tty_mode-headset">
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ASRC1IN2R Input" value="AIF2RX1" />
+		<ctl name="HPOUT1L Input 2" value="ASRC1IN2L" />
+		<ctl name="HPOUT1R Input 2" value="ASRC1IN2L" />
+		<ctl name="HPOUT1L Input 1" value="AIF1RX1" />
+		<ctl name="HPOUT1R Input 1" value="AIF1RX2" />
+		<ctl name="HP Switch" value="1" />
+	</path>
+
+	<path name="tty_mode-headphone">
+		<path name="tty_mode-headset" />
+	</path>
+
+	<!-- call forwarding output -->
+	<path name="call_forwarding_master">
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ASRC1IN1L Input" value="AIF1RX1" />
+		<ctl name="ASRC1IN1R Input" value="AIF1RX2" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+	</path>
+
+	<path name="call_forwarding_slave-handset">
+		<path name="communication-handset" />
+	</path>
+
+	<path name="call_forwarding_slave-speaker">
+		<path name="communication-speaker" />
+	</path>
+
+	<path name="call_forwarding_slave-headset">
+		<path name="communication-headset" />
+	</path>
+
+	<path name="call_forwarding_slave-headphone">
+		<path name="communication-headphone" />
+	</path>
+
+	<path name="call_forwarding_slave-bt-sco-headset">
+		<path name="communication-bt-sco-headset" />
+	</path>
+
+	<path name="call_forwarding_slave-bt-ble-headset">
+		<path name="communication-bt-sco-headset" />
+	</path>
+
+	<!-- remote mic output -->
+	<path name="remote-bt-ble-headset">
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2DEC1 Input" value="AIF1RX1" />
+		<ctl name="ISRC2DEC2 Input" value="AIF1RX2" />
+		<ctl name="AIF3TX1 Input 1" value="ISRC2DEC1" />
+		<ctl name="AIF3TX2 Input 1" value="ISRC2DEC2" />
+	</path>
+
+	<!-- Input stage -->
+	<path name="main-mic">
+		<ctl name="LHPF1 Input 1" value="IN1L" />
+		<ctl name="Main Mic Switch" value="1" />
+	</path>
+
+	<path name="2nd-mic">
+		<ctl name="LHPF2 Input 1" value="IN3L" />
+		<ctl name="Sub Mic Switch" value="1" />
+	</path>
+
+	<path name="3rd-mic">
+		<ctl name="LHPF2 Input 1" value="IN4R" />
+		<ctl name="Third Mic Switch" value="1" />
+	</path>
+
+	<path name="headset-mic">
+		<ctl name="LHPF1 Input 1" value="IN2L" />
+		<ctl name="Headset Mic Switch" value="1" />
+	</path>
+
+	<!-- media input -->
+	<path name="media-mic">
+		<path name="capture_channel_left" />
+		<path name="main-mic" />
+	</path>
+
+	<path name="media-headset-mic">
+		<path name="capture_channel_left" />
+		<path name="headset-mic" />
+	</path>
+
+	<path name="media-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="media-bt-sco-headset-in">
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2INT1 Input" value="AIF3RX1" />
+		<ctl name="ISRC2INT2 Input" value="AIF3RX2" />
+		<ctl name="AIF1TX1 Input 1" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC2INT2" />
+	</path>
+
+	<!-- camcorder input -->
+	<path name="camcorder-mic">
+		<path name="capture_channel_invert" />
+		<path name="main-mic" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="camcorder-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="camcorder-headphone-mic">
+		<path name="camcorder-mic" />
+	</path>
+
+	<!-- voice input -->
+	<path name="recording-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="recording-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="recording-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="recording-bt-sco-headset-in">
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<!-- jam voice input -->
+	<path name="recording-jam-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="recording-jam-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<!-- interview input -->
+	<path name="interview-mic">
+		<ctl name="Sample Rate 2" value="24kHz" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="DSP2 Firmware" value="TX_SWB_INTERVIEW" />
+		<ctl name="DSP3 Firmware" value="TX_SWB_INTERVIEW" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP2 Aux 6" value="IN1L" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC2" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC1" />
+		<ctl name="ISRC1INT1 Input" value="DSP3.1" />
+		<ctl name="ISRC1INT2 Input" value="DSP3.2" />
+		<ctl name="AIF1TX1 Input 1" value="ISRC1INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC1INT2" />
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+	</path>
+
+	<!-- meeting input -->
+	<path name="meeting-mic">
+		<!-- TODO: We will make this -->
+	</path>
+
+	<!-- lpsd control input -->
+	<path name="lpsd_control-mic">
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP6 Rate" value="SYNCCLK rate 2" />
+		<ctl name="VoiceControl Mode" value="LPSD" />
+		<ctl name="DSP6 Firmware" value="LPSD" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="DSP6 Aux 1" value="ISRC1DEC1" />
+		<ctl name="DSP Virtual Output Mux" value="DSP6" />
+		<ctl name="Main Mic Switch" value="1" />
+	</path>
+
+	<!-- voice control input -->
+	<path name="voice_control-mic">
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="VoiceControl Mode" value="Normal" />
+		<ctl name="In Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP6 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP6 Firmware" value="VOICECONTROL" />
+		<ctl name="IN1 OSR" value="768kHz" />
+		<ctl name="DSP6 Aux 1" value="IN1L" />
+		<ctl name="DSP Virtual Output Mux" value="DSP6" />
+		<ctl name="Main Mic Switch" value="1" />
+	</path>
+
+	<!-- voice_control_with_okgoogle input -->
+	<path name="voice_control_with_okgoogle-mic">
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP6 Rate" value="SYNCCLK rate 2" />
+		<ctl name="VoiceControl Mode" value="Normal" />
+		<ctl name="In Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP6 Firmware" value="VOICECONTROL" />
+		<ctl name="IN1 OSR" value="1.536MHz" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="DSP6 Aux 1" value="ISRC2DEC1" />
+		<ctl name="DSP Virtual Output Mux" value="DSP6" />
+		<ctl name="Main Mic Switch" value="1" />
+	  <!--recording route -->
+		<ctl name="LHPF1 Input 1" value="IN1L" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<!-- voice_control_with_okgoogle input headset -->
+	<path name="voice_control_with_okgoogle-headset-mic">
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="DSP6 Rate" value="SYNCCLK rate 2" />
+		<ctl name="VoiceControl Mode" value="Normal" />
+		<ctl name="In Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP6 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP6 Firmware" value="VOICECONTROL" />
+		<ctl name="IN1 OSR" value="1.536MHz" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="DSP6 Aux 1" value="ISRC2DEC1" />
+		<ctl name="DSP Virtual Output Mux" value="DSP6" />
+		<ctl name="Main Mic Switch" value="1" />
+	  <!--recording route -->
+		<ctl name="Headset Mic Switch" value="1" />
+		<ctl name="LHPF1 Input 1" value="IN2L" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<!-- recognition input -->
+	<path name="recognition-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="recognition-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="recognition-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="recognition-bt-sco-headset-in">
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<!-- bargein samsung input -->
+	<path name="bargein_samsung_engine-mic">
+		<path name="2nd-mic" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF2" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC4DEC1" />
+	</path>
+
+	<path name="bargein_samsung_engine-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="bargein_samsung_engine-bt-sco-headset-in">
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<!-- bargein external input -->
+	<path name="bargein_external_engine-mic">
+		<path name="2nd-mic" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF2" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC4DEC1" />
+	</path>
+
+	<path name="bargein_external_engine-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="bargein_external_engine-bt-sco-headset-in">
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<!-- svoice/carmode samsung input -->
+	<path name="dualmic_samsung_engine-mic">
+		<path name="capture_channel_stereo" />
+		<path name="main-mic" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="dualmic_samsung_engine-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="dualmic_samsung_engine-bt-sco-headset-in">
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<!-- svoice/carmode external input -->
+	<path name="dualmic_external_engine-mic">
+		<path name="dualmic_samsung_engine-mic" />
+	</path>
+
+	<path name="dualmic_external_engine-headset-mic">
+		<path name="dualmic_samsung_engine-headset-mic" />
+	</path>
+
+	<path name="dualmic_external_engine-bt-sco-headset-in">
+		<path name="dualmic_samsung_engine-bt-sco-headset-in" />
+	</path>
+
+	<!-- communication input -->
+	<path name="communication-handset-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="communication-speaker-mic">
+		<path name="capture_channel_right" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="communication-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="communication-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="communication-bt-sco-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<path name="communication-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-mic" />
+	</path>
+
+	<!-- samsung voip input -->
+	<path name="samsung_voip-handset-mic">
+		<path name="capture_channel_stereo" />
+		<path name="main-mic" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="samsung_voip-speaker-mic">
+		<path name="capture_channel_invert" />
+		<path name="main-mic" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="samsung_voip-headset-mic">
+		<path name="communication-headset-mic" />
+	</path>
+
+	<path name="samsung_voip-headphone-mic">
+		<path name="communication-headphone-mic" />
+	</path>
+
+	<path name="samsung_voip-bt-sco-headset-in">
+		<path name="communication-bt-sco-headset-in" />
+	</path>
+
+	<path name="samsung_voip-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-mic" />
+	</path>
+
+	<!-- voip input -->
+	<path name="voip-handset-mic">
+		<path name="communication-handset-mic" />
+	</path>
+
+	<path name="voip-speaker-mic">
+		<path name="communication-speaker-mic" />
+	</path>
+
+	<path name="voip-headset-mic">
+		<path name="communication-headset-mic" />
+	</path>
+
+	<path name="voip-headphone-mic">
+		<path name="communication-headphone-mic" />
+	</path>
+
+	<path name="voip-bt-sco-headset-in">
+		<path name="communication-bt-sco-headset-in" />
+	</path>
+
+	<path name="voip-bt-ble-headset-in">
+		<path name="communication-bt-ble-headset-in" />
+	</path>
+
+	<!-- wificall input -->
+	<!-- wificall AP NB -->
+	<path name="wificall_nb-handset-mic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 3" value="8kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="ISRC1DEC4 Input" value="ISRC2INT1" />
+		<ctl name="DSP2 Firmware" value="TX_NB" />
+		<ctl name="DSP3 Firmware" value="TX_NB" />
+		<ctl name="DSP2 Aux 6" value="ISRC2DEC1" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC1" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC2" />
+		<ctl name="DSP3 Aux 1" value="ISRC1DEC4" />
+		<ctl name="ISRC1INT1 Input" value="DSP3.1" />
+		<ctl name="AIF1TX1 Input 1" value="ISRC1INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC1INT1" />
+	</path>
+
+	<path name="wificall_nb-speaker-mic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 3" value="8kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="ISRC2DEC2 Input" value="IN3L" />
+		<ctl name="ISRC1DEC4 Input" value="DSP5.1" />
+		<ctl name="DSP2 Firmware" value="TX_NB" />
+		<ctl name="DSP3 Firmware" value="TX_NB" />
+		<ctl name="DSP2 Aux 6" value="ISRC1DEC2" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC2" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC1" />
+		<ctl name="DSP3 Aux 1" value="ISRC1DEC4" />
+		<ctl name="ISRC1INT1 Input" value="DSP3.1" />
+		<ctl name="AIF1TX1 Input 1" value="ISRC1INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC1INT1" />
+	</path>
+
+	<path name="wificall_nb-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="wificall_nb-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="wificall_nb-bt-sco-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-bt-sco-headset-in" />
+	</path>
+	
+	<path name="wificall_nb-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-mic" />
+	</path>
+
+	<!-- wificall NB/EXTRA_VOL -->
+	<path name="wificall_nb_extra_vol-handset-mic">
+		<path name="wificall_nb-handset-mic" />
+	</path>
+
+	<path name="wificall_nb_extra_vol-speaker-mic">
+		<path name="wificall_nb-speaker-mic" />
+	</path>
+
+	<!-- wificall AP WB -->
+	<path name="wificall_wb-handset-mic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="ISRC2DEC2 Input" value="IN3L" />
+		<ctl name="DSP2 Firmware" value="TX_WB" />
+		<ctl name="DSP3 Firmware" value="TX_WB" />
+		<ctl name="DSP2 Aux 6" value="ISRC2DEC1" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC2DEC1" />
+		<ctl name="DSP3R Input 1" value="ISRC2DEC2" />
+		<ctl name="DSP3 Aux 1" value="DSP4.3" />
+		<ctl name="ISRC2INT2 Input" value="DSP3.1" />
+		<ctl name="AIF1TX1 Input 1" value="ISRC2INT2" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC2INT2" />
+	</path>
+
+	<path name="wificall_wb-speaker-mic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="ISRC2DEC2 Input" value="IN3L" />
+		<ctl name="ISRC2DEC4 Input" value="DSP5.1" />
+		<ctl name="DSP2 Firmware" value="TX_WB" />
+		<ctl name="DSP3 Firmware" value="TX_WB" />
+		<ctl name="DSP2 Aux 6" value="ISRC2DEC2" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC2DEC2" />
+		<ctl name="DSP3R Input 1" value="ISRC2DEC1" />
+		<ctl name="DSP3 Aux 1" value="ISRC2DEC4" />
+		<ctl name="ISRC2INT2 Input" value="DSP3.1" />
+		<ctl name="AIF1TX1 Input 1" value="ISRC2INT2" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC2INT2" />
+	</path>
+
+	<path name="wificall_wb-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="wificall_wb-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="wificall_wb-bt-sco-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-bt-sco-headset-in" />
+	</path>
+	
+	<path name="wificall_wb-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-mic" />
+	</path>
+
+	<!-- wificall WB/EXTRA_VOL -->
+	<path name="wificall_wb_extra_vol-handset-mic">
+		<path name="wificall_wb-handset-mic" />
+	</path>
+
+	<path name="wificall_wb_extra_vol-speaker-mic">
+		<path name="wificall_wb-speaker-mic" />
+	</path>
+
+	<!-- Video call input -->
+	<path name="video_call-handset-mic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 3" value="8kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="ISRC1DEC4 Input" value="ISRC2INT1" />
+		<ctl name="DSP2 Firmware" value="TX_NB" />
+		<ctl name="DSP3 Firmware" value="TX_NB" />
+		<ctl name="DSP2 Aux 6" value="ISRC2DEC1" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC1" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC2" />
+		<ctl name="DSP3 Aux 1" value="ISRC1DEC4" />
+		<ctl name="ISRC1INT1 Input" value="DSP3.1" />
+		<ctl name="AIF1TX1 Input 1" value="ISRC1INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC1INT1" />
+	</path>
+
+	<path name="video_call-speaker-mic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 3" value="8kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="ISRC2DEC2 Input" value="IN3L" />
+		<ctl name="ISRC1DEC4 Input" value="DSP5.1" />
+		<ctl name="DSP2 Firmware" value="TX_NB" />
+		<ctl name="DSP3 Firmware" value="TX_NB" />
+		<ctl name="DSP2 Aux 6" value="ISRC1DEC2" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC2" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC1" />
+		<ctl name="DSP3 Aux 1" value="ISRC1DEC4" />
+		<ctl name="ISRC1INT1 Input" value="DSP3.1" />
+		<ctl name="AIF1TX1 Input 1" value="ISRC1INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC1INT1" />
+	</path>
+
+	<path name="video_call-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="video_call-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="video_call-bt-sco-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<path name="video_call-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-mic" />
+	</path>
+
+	<!-- VoLTE AP input -->
+	<!-- VoLTE AP NB -->
+	<path name="volte_vt_ap_nb-handset-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="volte_vt_ap_nb-speaker-mic">
+		<path name="capture_channel_right" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="volte_vt_ap_nb-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="volte_vt_ap_nb-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="volte_vt_ap_nb-bt-sco-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<path name="volte_vt_ap_nb-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-mic" />
+	</path>
+
+	<!-- VoLTE AP WB -->
+	<path name="volte_vt_ap_wb-handset-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="volte_vt_ap_wb-speaker-mic">
+		<path name="capture_channel_right" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="volte_vt_ap_wb-headset-mic">
+		<path name="media-headset-mic" />
+	</path>
+
+	<path name="volte_vt_ap_wb-headphone-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="volte_vt_ap_wb-bt-sco-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-bt-sco-headset-in" />
+	</path>
+
+	<path name="volte_vt_ap_wb-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="media-mic" />
+	</path>
+
+	<!-- CP Call input -->
+	<!-- call default input -->
+	<path name="incall_default-handset-mic">
+		<path name="main-mic" />
+		<ctl name="AIF2 Mode" value="Slave" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="ASRC1IN1L Input" value="ISRC2DEC1" />
+		<ctl name="ASRC1IN1R Input" value="ISRC2DEC1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="capture_channel_left" />
+	</path>
+
+	<path name="incall_default-speaker-mic">
+		<path name="2nd-mic" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2DEC3 Input" value="IN3L" />
+		<ctl name="IN3L Digital Volume" value="0" />
+		<ctl name="ASRC1IN1L Input" value="ISRC2DEC3" />
+		<ctl name="ASRC1IN1R Input" value="ISRC2DEC3" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="capture_channel_right" />
+	</path>
+
+	<path name="incall_default-headset-mic">
+		<ctl name="Headset Mic Switch" value="1" />
+		<ctl name="ASRC1IN1L Input" value="IN2L" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1L" />
+		<!-- Call recording route -->
+		<ctl name="LHPF1 Input 1" value="IN2L" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<path name="incall_default-headphone-mic">
+		<path name="main-mic" />
+		<ctl name="ASRC1IN1L Input" value="LHPF1" />
+		<ctl name="ASRC1IN1R Input" value="LHPF1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="capture_channel_left" />
+	</path>
+
+	<path name="incall_default-bt-sco-headset-in">
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2INT1 Input" value="AIF3RX1" />
+		<ctl name="ISRC2INT2 Input" value="AIF3RX2" />
+		<ctl name="ASRC1IN1L Input" value="ISRC2INT1" />
+		<ctl name="ASRC1IN1R Input" value="ISRC2INT2" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 1" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC2INT2" />
+	</path>
+
+	<path name="incall_default-bt-ble-headset-in">
+		<path name="incall_default-headphone-mic" />
+	</path>
+
+	<!-- NB -->
+	<path name="incall_nb-handset-mic">
+		<ctl name="Headset Mic Switch" value="0" />
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 3" value="8kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC3 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC3 FSH" value="SYNCCLK rate 2" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="LHPF3 Input 1" value="AIF1RX1" />
+		<ctl name="LHPF3 Input 2" value="ISRC2INT1" />
+		<ctl name="ISRC1DEC4 Input" value="LHPF3" />
+		<ctl name="DSP2 Firmware" value="TX_NB" />
+		<ctl name="DSP3 Firmware" value="TX_NB" />
+		<ctl name="DSP2 Aux 6" value="ISRC2DEC1" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC1" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC2" />
+		<ctl name="DSP3 Aux 1" value="ISRC1DEC4" />
+		<ctl name="ISRC3INT1 Input" value="DSP3.1" />
+		<ctl name="ASRC1IN1L Input" value="ISRC3INT1" />
+		<ctl name="ASRC1IN1R Input" value="ISRC3INT1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<!-- Call recording route -->
+		<ctl name="ISRC1INT1 Input" value="DSP3.1" />
+		<ctl name="LHPF1 Input 1" value="ISRC1INT1" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<path name="incall_nb-speaker-mic">
+		<ctl name="Headset Mic Switch" value="0" />
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 3" value="8kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC3 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC3 FSH" value="SYNCCLK rate 2" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="ISRC2DEC2 Input" value="IN3L" />
+		<ctl name="ISRC1DEC4 Input" value="DSP5.1" />
+		<ctl name="DSP2 Firmware" value="TX_NB" />
+		<ctl name="DSP3 Firmware" value="TX_NB" />
+		<ctl name="DSP2 Aux 6" value="ISRC1DEC2" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC2" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC1" />
+		<ctl name="DSP3 Aux 1" value="ISRC1DEC4" />
+		<ctl name="ISRC3INT1 Input" value="DSP3.1" />
+		<ctl name="ASRC1IN1L Input" value="ISRC3INT1" />
+		<ctl name="ASRC1IN1R Input" value="ISRC3INT1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<!-- Call recording route -->
+		<ctl name="ISRC1INT1 Input" value="DSP3.1" />
+		<ctl name="LHPF2 Input 1" value="ISRC1INT1" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF2" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF2" />
+	</path>
+
+	<path name="incall_nb-headset-mic">
+		<ctl name="Headset Mic Switch" value="1" />
+		<ctl name="ASRC1IN1L Input" value="IN2L" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1L" />
+		<!-- Call recording route -->
+		<ctl name="LHPF1 Input 1" value="IN2L" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<path name="incall_nb-headphone-mic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="ASRC1IN1L Input" value="IN1L" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1L" />
+		<!-- Call recording route -->
+		<ctl name="LHPF1 Input 1" value="IN1L" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<path name="incall_nb-bt-sco-headset-in">
+		<path name="mute-speaker" />
+		<ctl name="Sample Rate 2" value="8kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2INT1 Input" value="AIF3RX1" />
+		<ctl name="ISRC2INT2 Input" value="AIF3RX2" />
+		<ctl name="ASRC1IN1L Input" value="ISRC2INT1" />
+		<ctl name="ASRC1IN1R Input" value="ISRC2INT2" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 1" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC2INT2" />
+	</path>
+
+	<path name="incall_nb-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="incall_nb-headphone-mic" />
+	</path>
+
+	<!-- NB/HANDOVER -->
+	<path name="incall_nb_handover-handset-mic">
+		<path name="incall_nb-handset-mic" />
+	</path>
+
+	<path name="incall_nb_handover-speaker-mic">
+		<path name="incall_nb-speaker-mic" />
+	</path>
+
+	<path name="incall_nb_handover-headset-mic">
+		<ctl name="Headset Mic Switch" value="1" />
+		<ctl name="ISRC2DEC3 Input" value="IN2L" />
+		<ctl name="ASRC1IN1L Input" value="ISRC2DEC3" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1L" />
+		<!-- Call recording route -->
+		<ctl name="LHPF1 Input 1" value="IN2L" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<path name="incall_nb_handover-headphone-mic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="ASRC1IN1L Input" value="ISRC2DEC1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1L" />
+		<!-- Call recording route -->
+		<ctl name="LHPF1 Input 1" value="IN1L" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<!-- NB/EXTRA_VOL -->
+	<path name="incall_nb_extra_vol-handset-mic">
+		<path name="incall_nb-handset-mic" />
+	</path>
+
+	<path name="incall_nb_extra_vol-speaker-mic">
+		<path name="incall_nb-speaker-mic" />
+	</path>
+
+	<!-- NB/EXTRA_VOL/HANDOVER -->
+	<path name="incall_nb_extra_vol_handover-handset-mic">
+		<path name="incall_nb-handset-mic" />
+	</path>
+
+	<path name="incall_nb_extra_vol_handover-speaker-mic">
+		<path name="incall_nb-speaker-mic" />
+	</path>
+
+	<!-- WB -->
+	<path name="incall_wb-handset-mic">
+		<ctl name="Headset Mic Switch" value="0" />
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="EQ1 Input 1" value="IN1L" />
+		<ctl name="EQ2 Input 1" value="IN3L" />
+		<ctl name="ISRC2DEC1 Input" value="EQ1" />
+		<ctl name="ISRC2DEC2 Input" value="EQ2" />
+		<ctl name="LHPF3 Input 1" value="AIF1RX1" />
+		<ctl name="LHPF3 Input 2" value="ISRC2INT1" />
+		<ctl name="ISRC2DEC4 Input" value="LHPF3" />
+		<ctl name="DSP2 Firmware" value="TX_WB" />
+		<ctl name="DSP3 Firmware" value="TX_WB" />
+		<ctl name="DSP2 Aux 6" value="ISRC2DEC1" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC2DEC1" />
+		<ctl name="DSP3R Input 1" value="ISRC2DEC2" />
+		<ctl name="DSP3 Aux 1" value="ISRC2DEC4" />
+		<ctl name="ASRC1IN1L Input" value="DSP3.1" />
+		<ctl name="ASRC1IN1R Input" value="DSP3.1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<!-- Call recording route -->
+		<ctl name="ISRC2INT2 Input" value="DSP3.1" />
+		<ctl name="LHPF1 Input 1" value="ISRC2INT2" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
+	</path>
+
+	<path name="incall_wb-speaker-mic">
+		<ctl name="Headset Mic Switch" value="0" />
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 2" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="EQ3 Input 1" value="IN1L" />
+		<ctl name="EQ4 Input 1" value="IN3L" />
+		<ctl name="ISRC2DEC1 Input" value="EQ3" />
+		<ctl name="ISRC2DEC2 Input" value="EQ4" />
+		<ctl name="ISRC2DEC4 Input" value="DSP5.1" />
+		<ctl name="DSP2 Firmware" value="TX_WB" />
+		<ctl name="DSP3 Firmware" value="TX_WB" />
+		<ctl name="DSP2 Aux 6" value="ISRC2DEC2" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC2DEC2" />
+		<ctl name="DSP3R Input 1" value="ISRC2DEC1" />
+		<ctl name="DSP3 Aux 1" value="ISRC2DEC4" />
+		<ctl name="ASRC1IN1L Input" value="DSP3.1" />
+		<ctl name="ASRC1IN1R Input" value="DSP3.1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<!-- Call recording route -->
+		<ctl name="ISRC2INT2 Input" value="DSP3.1" />
+		<ctl name="LHPF2 Input 1" value="ISRC2INT2" />
+		<ctl name="AIF1TX1 Input 1" value="LHPF2" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF2" />
+	</path>
+
+	<path name="incall_wb-headset-mic">
+		<path name="incall_nb-headset-mic" />
+	</path>
+
+	<path name="incall_wb-headphone-mic">
+		<path name="incall_nb-headphone-mic" />
+	</path>
+
+	<path name="incall_wb-bt-sco-headset-in">
+		<path name="mute-speaker" />
+		<ctl name="Sample Rate 2" value="16kHz" />
+		<ctl name="ASRC1 Rate 1" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2 FSL" value="SYNCCLK rate 2" />
+		<ctl name="ISRC2 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC2INT1 Input" value="AIF3RX1" />
+		<ctl name="ISRC2INT2 Input" value="AIF3RX2" />
+		<ctl name="ASRC1IN1L Input" value="ISRC2INT1" />
+		<ctl name="ASRC1IN1R Input" value="ISRC2INT2" />	
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<!-- Call recording route -->
+		<ctl name="AIF1TX1 Input 1" value="ISRC2INT1" />
+		<ctl name="AIF1TX2 Input 1" value="ISRC2INT2" />
+	</path>
+
+	<path name="incall_wb-bt-ble-headset-in">
+		<path name="mute-speaker" />
+		<path name="incall_nb-headphone-mic" />
+	</path>
+
+	<!-- WB/EXTRA_VOL -->	
+	<path name="incall_wb_extra_vol-handset-mic">
+		<path name="incall_wb-handset-mic" />
+	</path>
+
+	<path name="incall_wb_extra_vol-speaker-mic">
+		<path name="incall_wb-speaker-mic" />
+	</path>
+
+	<!-- VoLTE CP input -->
+	<!-- VoLTE CP NB -->
+	<path name="volte_cp_nb-handset-mic">
+		<path name="incall_nb-handset-mic" />
+	</path>
+
+	<path name="volte_cp_nb-speaker-mic">
+		<path name="incall_nb-speaker-mic" />
+	</path>
+
+	<path name="volte_cp_nb-headset-mic">
+		<path name="incall_nb-headset-mic" />
+	</path>
+
+	<path name="volte_cp_nb-headphone-mic">
+		<path name="incall_nb-headphone-mic" />
+	</path>
+
+	<path name="volte_cp_nb-bt-sco-headset-in">
+		<path name="incall_nb-bt-sco-headset-in" />
+	</path>
+
+	<path name="volte_cp_nb-bt-ble-headset-in">
+		<path name="incall_nb-bt-ble-headset-in" />
+	</path>
+
+	<!-- VoLTE CP NB/HANDOVER -->
+	<path name="volte_cp_nb_handover-handset-mic">
+		<path name="incall_nb-handset-mic" />
+	</path>
+
+	<path name="volte_cp_nb_handover-speaker-mic">
+		<path name="incall_nb-speaker-mic" />
+	</path>
+
+	<path name="volte_cp_nb_handover-headset-mic">
+		<path name="incall_nb_handover-headset-mic" />
+	</path>
+
+	<path name="volte_cp_nb_handover-headphone-mic">
+		<path name="incall_nb_handover-headphone-mic" />
+	</path>
+
+	<!-- VoLTE CP NB/EXTRA_VOL-->
+	<path name="volte_cp_nb_extra_vol-handset-mic">
+		<path name="incall_nb-handset-mic" />
+	</path>
+
+	<path name="volte_cp_nb_extra_vol-speaker-mic">
+		<path name="incall_nb-speaker-mic" />
+	</path>
+
+	<!-- VoLTE CP NB/EXTRA_VOL/HANDOVER -->
+	<path name="volte_cp_nb_extra_vol_handover-handset-mic">
+		<path name="incall_nb-handset-mic" />
+	</path>
+
+	<path name="volte_cp_nb_extra_vol_handover-speaker-mic">
+		<path name="incall_nb-speaker-mic" />
+	</path>
+
+	<!-- VoLTE VT CP NB-->
+	<path name="volte_vt_cp_nb-handset-mic">
+		<path name="incall_nb-handset-mic" />
+	</path>
+
+	<path name="volte_vt_cp_nb-speaker-mic">
+		<path name="incall_nb-speaker-mic" />
+	</path>
+
+	<path name="volte_vt_cp_nb-headset-mic">
+		<path name="incall_nb-headset-mic" />
+	</path>
+
+	<path name="volte_vt_cp_nb-headphone-mic">
+		<path name="incall_nb-headphone-mic" />
+	</path>
+
+	<path name="volte_vt_cp_nb-bt-sco-headset-in">
+		<path name="incall_nb-bt-sco-headset-in" />
+	</path>
+
+	<path name="volte_vt_cp_nb-bt-ble-headset-in">
+		<path name="incall_nb-bt-ble-headset-in" />
+	</path>
+
+	<!-- VoLTE CP WB -->
+	<path name="volte_cp_wb-handset-mic">
+		<path name="incall_wb-handset-mic" />
+	</path>
+
+	<path name="volte_cp_wb-speaker-mic">
+		<path name="incall_wb-speaker-mic" />
+	</path>
+
+	<path name="volte_cp_wb-headset-mic">
+		<path name="incall_wb-headset-mic" />
+	</path>
+
+	<path name="volte_cp_wb-headphone-mic">
+		<path name="incall_wb-headphone-mic" />
+	</path>
+
+	<path name="volte_cp_wb-bt-sco-headset-in">
+		<path name="incall_wb-bt-sco-headset-in" />
+	</path>
+
+	<path name="volte_cp_wb-bt-ble-headset-in">
+		<path name="incall_wb-bt-ble-headset-in" />
+	</path>
+
+	<!-- VoLTE CP WB/EXTRA_VOL -->
+	<path name="volte_cp_wb_extra_vol-handset-mic">
+		<path name="incall_wb-handset-mic" />
+	</path>
+
+	<path name="volte_cp_wb_extra_vol-speaker-mic">
+		<path name="incall_wb-speaker-mic" />
+	</path>
+
+	<!-- VoLTE VT CP WB -->
+	<path name="volte_vt_cp_wb-handset-mic">
+		<path name="incall_wb-handset-mic" />
+	</path>
+
+	<path name="volte_vt_cp_wb-speaker-mic">
+		<path name="incall_wb-speaker-mic" />
+	</path>
+
+	<path name="volte_vt_cp_wb-headset-mic">
+		<path name="incall_wb-headset-mic" />
+	</path>
+
+	<path name="volte_vt_cp_wb-headphone-mic">
+		<path name="incall_wb-headphone-mic" />
+	</path>
+
+	<path name="volte_vt_cp_wb-bt-sco-headset-in">
+		<path name="incall_wb-bt-sco-headset-in" />
+	</path>
+
+	<path name="volte_vt_cp_wb-bt-ble-headset-in">
+		<path name="incall_wb-bt-ble-headset-in" />
+	</path>
+
+	<!-- Loopback Input (no delay) -->
+	<path name="loopback-mic">
+		<ctl name="ASRC1IN1L Input" value="LHPF1" />
+		<ctl name="ASRC1IN1R Input" value="LHPF1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="main-mic" />
+	</path>
+
+	<path name="loopback-2nd-mic">
+		<ctl name="ASRC1IN1L Input" value="LHPF2" />
+		<ctl name="ASRC1IN1R Input" value="LHPF2" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="2nd-mic" />
+	</path>
+
+	<!-- Packet Loopback Input -->
+	<path name="loopback_packet-mic">
+		<ctl name="ASRC1IN1L Input" value="LHPF1" />
+		<ctl name="ASRC1IN1R Input" value="LHPF1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="main-mic" />
+	</path>
+
+	<path name="loopback_packet-2nd-mic">
+		<ctl name="ASRC1IN1L Input" value="LHPF2" />
+		<ctl name="ASRC1IN1R Input" value="LHPF2" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="loopback_packet-3rd-mic">
+		<ctl name="ASRC1IN1L Input" value="LHPF2" />
+		<ctl name="ASRC1IN1R Input" value="LHPF2" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="3rd-mic" />
+	</path>
+
+	<path name="loopback_packet-headset-mic">
+		<ctl name="ASRC1IN1L Input" value="LHPF1" />
+		<ctl name="ASRC1IN1R Input" value="LHPF1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+		<path name="headset-mic" />
+	</path>
+
+	<path name="loopback_packet-handset-dualmic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 3" value="8kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC3 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC3 FSH" value="SYNCCLK rate 2" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC2DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="LHPF3 Input 1" value="AIF1RX1" />
+		<ctl name="LHPF3 Input 2" value="ISRC2INT1" />
+		<ctl name="ISRC1DEC4 Input" value="LHPF3" />
+		<ctl name="DSP2 Firmware" value="TX_NB" />
+		<ctl name="DSP3 Firmware" value="TX_NB" />
+		<ctl name="DSP2 Aux 6" value="ISRC2DEC1" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC1" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC2" />
+		<ctl name="ISRC3INT1 Input" value="DSP3.1" />
+		<ctl name="ASRC1IN1L Input" value="ISRC3INT1" />
+		<ctl name="ASRC1IN1R Input" value="ISRC3INT1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+	</path>
+
+	<path name="loopback_packet-speaker-dualmic">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="Sub Mic Switch" value="1" />
+		<ctl name="Sample Rate 3" value="8kHz" />
+		<ctl name="DSP2 Rate" value="SYNCCLK rate 3" />
+		<ctl name="DSP3 Rate" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC1 FSH" value="SYNCCLK rate 1" />
+		<ctl name="ISRC3 FSL" value="SYNCCLK rate 3" />
+		<ctl name="ISRC3 FSH" value="SYNCCLK rate 2" />
+		<ctl name="ISRC1DEC1 Input" value="IN1L" />
+		<ctl name="ISRC1DEC2 Input" value="IN3L" />
+		<ctl name="ISRC2DEC2 Input" value="IN3L" />
+		<ctl name="LHPF3 Input 1" value="AIF1RX1" />
+		<ctl name="LHPF3 Input 2" value="ISRC2INT1" />
+		<ctl name="ISRC1DEC4 Input" value="LHPF3" />
+		<ctl name="DSP2 Firmware" value="TX_NB" />
+		<ctl name="DSP3 Firmware" value="TX_NB" />
+		<ctl name="DSP2 Aux 6" value="ISRC1DEC2" />
+		<ctl name="DSP3 Virtual Input" value="Shared Memory" />
+		<ctl name="DSP3L Input 1" value="ISRC1DEC2" />
+		<ctl name="DSP3R Input 1" value="ISRC1DEC1" />
+		<ctl name="ISRC3INT1 Input" value="DSP3.1" />
+		<ctl name="ASRC1IN1L Input" value="ISRC3INT1" />
+		<ctl name="ASRC1IN1R Input" value="ISRC3INT1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+	</path>
+
+	<!-- TTY Mode Input -->
+	<path name="tty_mode-vco-mic">
+		<path name="main-mic" />
+		<ctl name="ASRC1IN1L Input" value="LHPF1" />
+		<ctl name="ASRC1IN1R Input" value="LHPF1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+	</path>
+
+	<path name="tty_mode-full-mic">
+		<path name="headset-mic" />
+		<ctl name="ASRC1IN1L Input" value="LHPF1" />
+		<ctl name="ASRC1IN1R Input" value="LHPF1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+	</path>
+
+	<path name="tty_mode-hco-mic">
+		<path name="headset-mic" />
+		<ctl name="ASRC1IN1L Input" value="LHPF1" />
+		<ctl name="ASRC1IN1R Input" value="LHPF1" />
+		<ctl name="AIF2TX1 Input 1" value="ASRC1IN1L" />
+		<ctl name="AIF2TX2 Input 1" value="ASRC1IN1R" />
+	</path>
+
+	<!-- echo(rms) test input -->
+	<path name="echo_test-mic">
+		<path name="media-mic" />
+	</path>
+
+	<path name="echo_test-2nd-mic">
+		<path name="capture_channel_right" />
+		<path name="2nd-mic" />
+	</path>
+
+	<path name="echo_test-3rd-mic">
+		<path name="capture_channel_right" />
+		<path name="3rd-mic" />
+	</path>
+
+	<path name="echo_test-dualmic">
+		<path name="capture_channel_stereo" />
+		<path name="main-mic" />
+		<path name="2nd-mic" />
+	</path>
+
+	<!-- call forwarding input -->
+	<path name="call_forwarding_master-mic">
+		<ctl name="ASRC1IN2L Input" value="AIF2RX1" />
+		<ctl name="ASRC1IN2R Input" value="AIF2RX1" />
+		<ctl name="AIF1TX1 Input 1" value="ASRC1IN2L" />
+		<ctl name="AIF1TX2 Input 1" value="ASRC1IN2R" />
+	</path>
+
+	<path name="call_forwarding_slave-handset-mic">
+		<path name="communication-handset-mic" />
+	</path>
+
+	<path name="call_forwarding_slave-speaker-mic">
+		<path name="communication-speaker-mic" />
+	</path>
+
+	<path name="call_forwarding_slave-headset-mic">
+		<path name="communication-headset-mic" />
+	</path>
+
+	<path name="call_forwarding_slave-headphone-mic">
+		<path name="communication-headphone-mic" />
+	</path>
+
+	<path name="call_forwarding_slave-bt-sco-headset-in">
+		<path name="communication-bt-sco-headset-in" />
+	</path>
+
+	<path name="call_forwarding_slave-bt-ble-headset-in">
+		<path name="communication-bt-ble-headset-in" />
+	</path>
+
+	<!-- remote mic input -->
+	<path name="remote-bt-ble-headset-in">
+		<ctl name="Main Mic Switch" value="1" />
+		<ctl name="ISRC2DEC3 Input" value="IN1L" />
+		<ctl name="ISRC2DEC4 Input" value="IN1L" />
+		<ctl name="AIF3TX1 Input 2" value="ISRC2DEC3" />
+		<ctl name="AIF3TX2 Input 2" value="ISRC2DEC4" />
+		<!-- remote mic recording route -->
+		<ctl name="AIF1TX1 Input 1" value="IN1L" />
+		<ctl name="AIF1TX2 Input 1" value="IN1L" />
+	</path>
+
+	<!-- One byte control -->
+	<path name="seamless_buf_offset">
+		<param name="DSP6 ZM 6000d:0" id="13" />
+		<param name="DSP6 ZM 6000d:0" id="14" />
+		<param name="DSP6 ZM 6000d:0" id="15" />
+	</path>
+
+	<path name="codec_rx_mute">
+		<param name="HPOUT1 Digital Switch" id="0" />
+		<param name="HPOUT3 Digital Switch" id="0" />
+		<param name="HPOUT1 Digital Switch" id="1" />
+		<param name="HPOUT3 Digital Switch" id="1" />
+		<param name="SPK Enable Switch" id="0" />
+	</path>
+
+	<!-- Output volume stage -->
+	<!-- media playback volume -->
+	<path name="gain-media-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="31" />
+		<ctl name="HPOUT3R Input 1 Volume" value="31" />
+	</path>
+
+	<path name="gain-media-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-media-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-media-speaker-headset">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="60" />
+		<ctl name="HPOUT1R Impedance Volume" value="60" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-media-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-media-speaker-bt-sco-headset">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- Ringtone playback volume -->
+	<path name="gain-ringtone-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-ringtone-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-ringtone-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-ringtone-speaker-headset">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="60" />
+		<ctl name="HPOUT1R Impedance Volume" value="60" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-ringtone-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-ringtone-speaker-bt-sco-headset">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- Communication playback volume -->
+	<path name="gain-communication-handset">
+		<ctl name="HPOUT3 Digital Volume" value="124" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-speaker">
+		<ctl name="AIF4TX1 Input 1 Volume" value="28" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="28" />
+		<ctl name="AIF4TX1 Input 2 Volume" value="28" />
+		<ctl name="AIF4TX2 Input 2 Volume" value="28" />
+	</path>
+
+	<path name="gain-communication-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="102" />
+		<ctl name="HPOUT1R Impedance Volume" value="102" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="102" />
+		<ctl name="HPOUT1R Impedance Volume" value="102" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- samsung voip playback volume -->
+	<path name="gain-samsung_voip-handset">
+		<ctl name="HPOUT3 Digital Volume" value="124" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-speaker">
+		<ctl name="AIF4TX1 Input 1 Volume" value="28" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="28" />
+		<ctl name="AIF4TX1 Input 2 Volume" value="28" />
+		<ctl name="AIF4TX2 Input 2 Volume" value="28" />
+	</path>
+
+	<path name="gain-samsung_voip-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="102" />
+		<ctl name="HPOUT1R Impedance Volume" value="102" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="102" />
+		<ctl name="HPOUT1R Impedance Volume" value="102" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- voip playback volume -->
+	<path name="gain-voip-handset">
+		<ctl name="HPOUT3 Digital Volume" value="126" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-speaker">
+		<ctl name="AIF4TX1 Input 1 Volume" value="25" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="25" />
+		<ctl name="AIF4TX1 Input 2 Volume" value="25" />
+		<ctl name="AIF4TX2 Input 2 Volume" value="25" />
+	</path>
+
+	<path name="gain-voip-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="102" />
+		<ctl name="HPOUT1R Impedance Volume" value="102" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="102" />
+		<ctl name="HPOUT1R Impedance Volume" value="102" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- wificall nb playback volume -->
+	<path name="gain-wificall_nb-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-wificall_nb-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-wificall_nb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-wificall_nb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-wificall_nb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+	
+	<path name="gain-wificall_nb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- wificall NB/EXTRA_VOL playback volume -->
+	<path name="gain-wificall_nb_extra_vol-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-wificall_nb_extra_vol-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 10 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<!-- wificall wb playback volume -->
+	<path name="gain-wificall_wb-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-wificall_wb-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-wificall_wb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="119" />
+		<ctl name="HPOUT1R Impedance Volume" value="119" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-wificall_wb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-wificall_wb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+	
+	<path name="gain-wificall_wb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- wificall WB/EXTRA_VOL playback volume -->
+	<path name="gain-wificall_wb_extra_vol-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-wificall_wb_extra_vol-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 10 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<!-- Video call playback volume -->
+	<path name="gain-video_call-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-video_call-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-video_call-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-video_call-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-video_call-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-video_call-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE AP NB playback volume -->
+	<path name="gain-volte_vt_ap_nb-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-speaker">
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE AP WB playback volume -->
+	<path name="gain-volte_vt_ap_wb-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-speaker">
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE CP NB playback volume -->
+	<path name="gain-volte_cp_nb-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_cp_nb-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_cp_nb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_nb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_nb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_nb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE CP NB/HANDOVER playback volume -->
+	<path name="gain-volte_cp_nb_handover-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 1 0 0 0 64 0 0 0 4 0 0 22 168 0 0 23 112 0 0 30 120 0 0 19 36 0 0 16 154 0 0 0 8 0 0 0 8 0 0 0 2 0 0 0 32 0 0 2 0 0 0 112 0 0 0 96 0 0 0 112 0 0 0 48 0 0 0 80 0 0 0 0 1" />
+	</path>
+
+	<path name="gain-volte_cp_nb_handover-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 4 0 0 0 64 0 0 0 4 0 0 10 140 0 0 21 224 0 0 22 168 0 0 23 112 0 0 24 56 0 0 1 106 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1" />
+	</path>
+
+	<path name="gain-volte_cp_nb_handover-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 1 0 0 0 64 0 0 0 4 0 0 22 168 0 0 23 112 0 0 30 120 0 0 19 36 0 0 16 154 0 0 0 8 0 0 0 8 0 0 0 2 0 0 0 32 0 0 2 0 0 0 112 0 0 0 96 0 0 0 112 0 0 0 48 0 0 0 80 0 0 0 0 1" />
+	</path>
+
+	<path name="gain-volte_cp_nb_handover-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 1 0 0 0 64 0 0 0 4 0 0 22 168 0 0 23 112 0 0 30 120 0 0 19 36 0 0 16 154 0 0 0 8 0 0 0 8 0 0 0 2 0 0 0 32 0 0 2 0 0 0 112 0 0 0 96 0 0 0 112 0 0 0 48 0 0 0 80 0 0 0 0 1" />
+	</path>
+
+	<!-- VoLTE CP NB/EXTRA_VOL playback volume -->
+	<path name="gain-volte_cp_nb_extra_vol-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_cp_nb_extra_vol-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 10 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<!-- VoLTE CP NB/EXTRA_VOL/HANDOVER playback volume -->
+	<path name="gain-volte_cp_nb_extra_vol_handover-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 1 0 0 0 64 0 0 0 4 0 0 22 168 0 0 23 112 0 0 30 120 0 0 19 36 0 0 16 154 0 0 0 8 0 0 0 8 0 0 0 2 0 0 0 32 0 0 2 0 0 0 112 0 0 0 96 0 0 0 112 0 0 0 48 0 0 0 80 0 0 0 0 1" />
+	</path>
+
+	<path name="gain-volte_cp_nb_extra_vol_handover-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 10 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 4 0 0 0 64 0 0 0 4 0 0 10 140 0 0 21 224 0 0 22 168 0 0 23 112 0 0 24 56 0 0 1 106 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1" />
+	</path>
+
+	<!-- VoLTE VT CP NB playback volume -->
+	<path name="gain-volte_vt_cp_nb-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE CP WB playback volume -->
+	<path name="gain-volte_cp_wb-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_cp_wb-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_cp_wb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="119" />
+		<ctl name="HPOUT1R Impedance Volume" value="119" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_wb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_wb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_wb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE CP WB/EXTRA_VOL playback volume -->
+	<path name="gain-volte_cp_wb_extra_vol-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_cp_wb_extra_vol-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 10 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<!-- VoLTE VT CP WB playback volume -->
+	<path name="gain-volte_vt_cp_wb-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="119" />
+		<ctl name="HPOUT1R Impedance Volume" value="119" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<!-- CP Call Output volume -->
+	<!-- default volume -->
+	<path name="gain-incall_default-handset">
+	</path>
+
+	<path name="gain-incall_default-speaker">
+	</path>
+
+	<path name="gain-incall_default-headset">
+	</path>
+
+	<path name="gain-incall_default-headphone">
+	</path>
+
+	<path name="gain-incall_default-bt-sco-headset">
+	</path>
+
+	<path name="gain-incall_default-bt-ble-headset">
+	</path>
+
+	<!-- NB volume -->
+	<path name="gain-incall_nb-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-incall_nb-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-incall_nb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_nb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_nb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_nb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+	<!-- NB/HANDOVER volume -->
+	<path name="gain-incall_nb_handover-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 1 0 0 0 64 0 0 0 4 0 0 22 168 0 0 23 112 0 0 30 120 0 0 19 36 0 0 16 154 0 0 0 8 0 0 0 8 0 0 0 2 0 0 0 32 0 0 2 0 0 0 112 0 0 0 96 0 0 0 112 0 0 0 48 0 0 0 80 0 0 0 0 1" />
+	</path>
+
+	<path name="gain-incall_nb_handover-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 4 0 0 0 64 0 0 0 4 0 0 10 140 0 0 21 224 0 0 22 168 0 0 23 112 0 0 24 56 0 0 1 106 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1" />
+	</path>
+
+	<path name="gain-incall_nb_handover-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 64 0 0 0 4 0 0 22 168 0 0 23 112 0 0 30 120 0 0 19 36 0 0 16 154 0 0 0 8 0 0 0 8 0 0 0 2 0 0 0 32 0 0 2 0 0 0 112 0 0 0 96 0 0 0 112 0 0 0 48 0 0 0 80 0 0 0 0 1" />
+	</path>
+
+	<path name="gain-incall_nb_handover-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 64 0 0 0 4 0 0 22 168 0 0 23 112 0 0 30 120 0 0 19 36 0 0 16 154 0 0 0 8 0 0 0 8 0 0 0 2 0 0 0 32 0 0 2 0 0 0 112 0 0 0 96 0 0 0 112 0 0 0 48 0 0 0 80 0 0 0 0 1" />
+	</path>
+
+	<!-- NB/EXTRA_VOL Volume-->	
+	<path name="gain-incall_nb_extra_vol-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-incall_nb_extra_vol-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 10 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<!-- NB/EXTRA_VOL/HANDOVER Volume-->	
+	<path name="gain-incall_nb_extra_vol_handover-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 1 0 0 0 64 0 0 0 4 0 0 22 168 0 0 23 112 0 0 30 120 0 0 19 36 0 0 16 154 0 0 0 8 0 0 0 8 0 0 0 2 0 0 0 32 0 0 2 0 0 0 112 0 0 0 96 0 0 0 112 0 0 0 48 0 0 0 80 0 0 0 0 1" />
+	</path>
+
+	<path name="gain-incall_nb_extra_vol_handover-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f010:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 10 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f010:1" value="0 0 0 0 0 0 0 4 0 0 0 64 0 0 0 4 0 0 10 140 0 0 21 224 0 0 22 168 0 0 23 112 0 0 24 56 0 0 1 106 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1" />
+	</path>
+
+	<!-- WB volume -->
+	<path name="gain-incall_wb-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 13 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-incall_wb-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 4 0 0 0 6 0 0 0 8 0 0 0 10 0 0 0 10 0 0 0 4 0 0 0 4 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-incall_wb-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="119" />
+		<ctl name="HPOUT1R Impedance Volume" value="119" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_wb-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_wb-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_wb-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- WB/EXTRA_VOL Volume-->	
+	<path name="gain-incall_wb_extra_vol-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 11 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<path name="gain-incall_wb_extra_vol-speaker">
+		<ctl name="DSP5L Input 1 Volume" value="26" />
+		<ctl name="DSP5L Input 2 Volume" value="26" />
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+		<param name="DSP4 XM f011:0" value="0 0 0 1 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 5 0 0 0 7 0 0 0 9 0 0 0 10 0 0 0 4 0 0 0 0 0 0 0 18 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1" />
+		<param name="DSP4 XM f011:1" value="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3" />
+	</path>
+
+	<!-- Loopback (no delay) volume -->
+	<path name="gain-loopback-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="124" />
+		<ctl name="HPOUT1R Impedance Volume" value="124" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<!-- Packet Loopback output volume-->
+	<path name="gain-loopback_packet-handset">
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-loopback_packet-speaker">
+		<ctl name="AIF4TX1 Input 1 Volume" value="37" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="37" />
+		<ctl name="AIF4TX1 Input 2 Volume" value="37" />
+		<ctl name="AIF4TX2 Input 2 Volume" value="37" />
+	</path>
+
+	<path name="gain-loopback_packet-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="110" />
+		<ctl name="HPOUT1R Impedance Volume" value="110" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<!-- TTY Mode volume-->
+	<path name="gain-tty_mode-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+		<ctl name="HPOUT3L Input 2 Volume" value="32" />
+		<ctl name="HPOUT3R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-tty_mode-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<path name="gain-tty_mode-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="112" />
+		<ctl name="HPOUT1R Impedance Volume" value="112" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+		<ctl name="HPOUT1L Input 2 Volume" value="32" />
+		<ctl name="HPOUT1R Input 2 Volume" value="32" />
+	</path>
+
+	<!-- call forwarding output volume -->
+	<path name="gain-call_forwarding_master">
+		<!-- we use default volume -->
+	</path>
+
+	<path name="gain-call_forwarding_slave-handset">
+		<ctl name="HPOUT3 Digital Volume" value="128" />
+		<ctl name="HPOUT3L Input 1 Volume" value="32" />
+		<ctl name="HPOUT3R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-speaker">
+		<ctl name="AIF4TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF4TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-headset">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-headphone">
+		<ctl name="Noise Gate Switch" value="0" />
+		<ctl name="HPOUT1L Impedance Volume" value="113" />
+		<ctl name="HPOUT1R Impedance Volume" value="113" />
+		<ctl name="HPOUT1L Input 1 Volume" value="32" />
+		<ctl name="HPOUT1R Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-bt-sco-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- remote mic output volume -->
+	<path name="gain-remote-bt-ble-headset">
+		<ctl name="AIF3TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- Input stage volume -->
+	<!-- media input volume -->
+	<path name="gain-media-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-media-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-media-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-media-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- camcorder input volume -->
+	<path name="gain-camcorder-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-camcorder-headset-mic">
+		<ctl name="IN2L Volume" value="27" />
+		<ctl name="IN2L Digital Volume" value="118" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-camcorder-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- voice recording input volume -->
+	<path name="gain-recording-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-recording-headset-mic">
+		<ctl name="IN2L Volume" value="27" />
+		<ctl name="IN2L Digital Volume" value="118" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-recording-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-recording-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- jam voice recording input volume -->
+	<path name="gain-recording-jam-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-recording-jam-headset-mic">
+		<ctl name="IN2L Volume" value="31" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- interview input volume -->
+	<path name="gain-interview-mic">
+		<ctl name="IN1L Digital Volume" value="152" />
+		<ctl name="IN3L Digital Volume" value="152" />
+	</path>
+
+	<!-- meeting input volume -->
+	<path name="gain-meeting-mic">
+		<!-- TODO: We will make this -->
+	</path>
+
+	<!-- lpsd control input volume -->
+	<path name="gain-lpsd_control-mic">
+		<ctl name="IN1L Digital Volume" value="145" />
+	</path>
+
+	<!-- voice control input volume -->
+	<path name="gain-voice_control-mic">
+		<ctl name="IN1L Digital Volume" value="145" />
+		<param name="DSP6 ZM 6000d:0" value="0 112 0 0 0 0 0 16 0 0 0 1" />
+		<param name="DSP6 ZM 24:0" value="0 0 128 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 4 176 0 0 5 128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 30 0 0 0 0" />
+	</path>
+
+	<!-- voice_control_with_okgoogle input volume -->
+	<path name="gain-voice_control_with_okgoogle-mic">
+		<ctl name="IN1L Digital Volume" value="145" />
+		<param name="DSP6 ZM 6000d:0" value="0 112 0 0 0 0 0 16 0 0 0 1" />
+		<param name="DSP6 ZM 24:0" value="0 0 128 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 4 176 0 0 5 128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 30 0 0 0 0" />
+	</path>
+
+	<!-- voice_control_with_okgoogle input volume -->
+	<path name="gain-voice_control_with_okgoogle-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="129" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<ctl name="IN1L Digital Volume" value="145" />
+		<param name="DSP6 ZM 6000d:0" value="0 112 0 0 0 0 0 16 0 0 0 1" />
+		<param name="DSP6 ZM 24:0" value="0 0 128 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 4 176 0 0 5 128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 30 0 0 0 0" />
+	</path>
+
+	<!-- recognition input volume -->
+	<path name="gain-recognition-mic">
+		<ctl name="IN1L Digital Volume" value="145" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-recognition-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="129" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-recognition-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="142" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-recognition-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- bargein samsung input volume -->
+	<path name="gain-bargein_samsung_engine-mic">
+		<ctl name="IN3L Digital Volume" value="154" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-bargein_samsung_engine-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-bargein_samsung_engine-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- bargein external input volume-->
+	<path name="gain-bargein_external_engine-mic">
+		<ctl name="IN3L Digital Volume" value="143" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-bargein_external_engine-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-bargein_external_engine-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- svoice/carmode samsung input volume -->
+	<path name="gain-dualmic_samsung_engine-mic">
+		<ctl name="IN1L Digital Volume" value="154" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<ctl name="IN3L Digital Volume" value="154" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-dualmic_samsung_engine-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-dualmic_samsung_engine-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- svoice/carmode external input volume -->
+	<path name="gain-dualmic_external_engine-mic">
+		<ctl name="IN1L Digital Volume" value="154" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<ctl name="IN3L Digital Volume" value="154" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-dualmic_external_engine-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-dualmic_external_engine-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- communication input volume -->
+	<path name="gain-communication-handset-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-speaker-mic">
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-headset-mic">
+		<ctl name="IN2L Volume" value="38" />
+		<ctl name="IN2L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-communication-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- samsung voip input volume -->
+	<path name="gain-samsung_voip-handset-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="104" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-headset-mic">
+		<ctl name="IN2L Volume" value="38" />
+		<ctl name="IN2L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-samsung_voip-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- voip input volume -->
+	<path name="gain-voip-handset-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-speaker-mic">
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-headset-mic">
+		<ctl name="IN2L Volume" value="38" />
+		<ctl name="IN2L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-voip-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- wificall nb input volume -->
+	<path name="gain-wificall_nb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-wificall_nb-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-wificall_nb-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-wificall_nb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-wificall_nb-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+	
+	<path name="gain-wificall_nb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- wificall NB/EXTRA_VOL input volume -->
+	<path name="gain-wificall_nb_extra_vol-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-wificall_nb_extra_vol-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<!-- wificall wb input volume -->
+	<path name="gain-wificall_wb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<param name="DSP3 XM f003:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 64 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 153 0 4 0 0 0 4 0 0 0 4 0 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 4 0 0 0 4 0 0 0 4 0 0 0 0 0 0 0 11 51 51 0 9 153 153 0 0 0 4 0 0 0 5 0 8 0 0 0 8 0 0 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 11 153 153 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 8 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 4 0 0 0 1 0 0 0 8 0 0 0 2 137 44 0 1 69 91" />
+		<param name="DSP3 XM f003:1" value="0 0 230 85 0 2 3 167 0 2 3 167 0 2 216 98 0 1 153 153 0 1 69 91 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 240 0 0 128 0 0 0 0 1 0 255 255 216 0 11 59 0 0 2 216 98 0 4 4 222 0 1 69 91 0 5 15 68 0 5 15 68 0 7 37 157 0 2 66 147 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 35 231 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-wificall_wb-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<param name="DSP3 XM f003:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 5 85 85 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 6 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 160 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 4 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 0 0 0 0 8 0 0 0 14 0 0 0 0 0 8 0 0 0 8 0 14 172 0 0 15 51 64 0 8 202 0 0 11 59 0 0 10 252 128 0 10 65 0 0 8 202 0 0 0 0 0 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 16 0 0 0 0 0 0 0 14 51 51 0 8 0 0 0 7 0 0 0 6 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 16 0 0 0 2 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 137 44 0 2 0 0" />
+		<param name="DSP3 XM f003:1" value="0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 15 194 143 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 1 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 8 0 0 0 128 0 2 102 102 0 0 12 0 0 8 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 0 0 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 127 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 8 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 0 179 51 0 0 47 225 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 204 192 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 0 0 100 0 4 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-wificall_wb-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-wificall_wb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-wificall_wb-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+	
+	<path name="gain-wificall_wb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- wificall WB/EXTRA_VOL input volume -->
+	<path name="gain-wificall_wb_extra_vol-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<param name="DSP3 XM f003:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 64 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 153 0 4 0 0 0 4 0 0 0 4 0 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 4 0 0 0 4 0 0 0 4 0 0 0 0 0 0 0 11 51 51 0 9 153 153 0 0 0 4 0 0 0 5 0 8 0 0 0 8 0 0 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 11 153 153 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 8 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 4 0 0 0 1 0 0 0 8 0 0 0 2 137 44 0 1 69 91" />
+		<param name="DSP3 XM f003:1" value="0 0 230 85 0 2 3 167 0 2 3 167 0 2 216 98 0 1 153 153 0 1 69 91 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 240 0 0 128 0 0 0 0 1 0 255 255 216 0 11 59 0 0 2 216 98 0 4 4 222 0 1 69 91 0 5 15 68 0 5 15 68 0 7 37 157 0 2 66 147 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 35 231 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-wificall_wb_extra_vol-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<param name="DSP3 XM f003:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 5 85 85 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 6 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 160 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 4 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 0 0 0 0 8 0 0 0 14 0 0 0 0 0 8 0 0 0 8 0 14 172 0 0 15 51 64 0 8 202 0 0 11 59 0 0 10 252 128 0 10 65 0 0 8 202 0 0 0 0 0 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 16 0 0 0 0 0 0 0 14 51 51 0 8 0 0 0 7 0 0 0 6 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 16 0 0 0 2 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 137 44 0 2 0 0" />
+		<param name="DSP3 XM f003:1" value="0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 15 194 143 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 1 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 8 0 0 0 128 0 2 102 102 0 0 12 0 0 8 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 0 0 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 127 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 8 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 0 179 51 0 0 47 225 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 204 192 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 0 0 100 0 4 0 0 0 0 90 90" />
+	</path>
+
+	<!-- Video call input volume -->
+	<path name="gain-video_call-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-video_call-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-video_call-headset-mic">
+		<ctl name="IN2L Volume" value="26" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-video_call-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-video_call-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-video_call-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE AP NB input volume -->
+	<path name="gain-volte_vt_ap_nb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-speaker-mic">
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_nb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE AP WB input volume -->
+	<path name="gain-volte_vt_ap_wb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-speaker-mic">
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_ap_wb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE VT CP NB input volume -->
+	<path name="gain-volte_vt_cp_nb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-bt-sco-headset-in">
+		<ctl name="AIF2TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF2TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_nb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE CP NB input volume -->
+	<path name="gain-volte_cp_nb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-volte_cp_nb-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-volte_cp_nb-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_nb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_nb-bt-sco-headset-in">
+		<ctl name="AIF2TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF2TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_nb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE CP NB/HANDOVER input volume -->
+	<path name="gain-volte_cp_nb_handover-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-volte_cp_nb_handover-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-volte_cp_nb_handover-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_nb_handover-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE VT CP NB/EXTRA_VOL input volume -->
+	<path name="gain-volte_cp_nb_extra_vol-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-volte_cp_nb_extra_vol-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<!-- VoLTE VT CP NB/EXTRA_VOL/HANDOVER input volume -->
+	<path name="gain-volte_cp_nb_extra_vol_handover-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-volte_cp_nb_extra_vol_handover-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<!-- VoLTE CP WB input volume -->
+	<path name="gain-volte_cp_wb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 64 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 153 0 4 0 0 0 4 0 0 0 4 0 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 4 0 0 0 4 0 0 0 4 0 0 0 0 0 0 0 11 51 51 0 9 153 153 0 0 0 4 0 0 0 5 0 8 0 0 0 8 0 0 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 11 153 153 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 8 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 4 0 0 0 1 0 0 0 8 0 0 0 2 137 44 0 1 69 91" />
+		<param name="DSP3 XM f003:1" value="0 0 230 85 0 2 3 167 0 2 3 167 0 2 216 98 0 1 153 153 0 1 69 91 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 240 0 0 128 0 0 0 0 1 0 255 255 216 0 11 59 0 0 2 216 98 0 4 4 222 0 1 69 91 0 5 15 68 0 5 15 68 0 7 37 157 0 2 66 147 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 35 231 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-volte_cp_wb-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 5 85 85 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 6 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 160 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 4 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 0 0 0 0 8 0 0 0 14 0 0 0 0 0 8 0 0 0 8 0 14 172 0 0 15 51 64 0 8 202 0 0 11 59 0 0 10 252 128 0 10 65 0 0 8 202 0 0 0 0 0 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 16 0 0 0 0 0 0 0 14 51 51 0 8 0 0 0 7 0 0 0 6 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 16 0 0 0 2 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 137 44 0 2 0 0" />
+		<param name="DSP3 XM f003:1" value="0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 15 194 143 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 1 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 8 0 0 0 128 0 2 102 102 0 0 12 0 0 8 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 0 0 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 127 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 8 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 0 179 51 0 0 47 225 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 204 192 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 0 0 100 0 4 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-volte_cp_wb-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_wb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_wb-bt-sco-headset-in">
+		<ctl name="AIF2TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF2TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_cp_wb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- VoLTE CP WB/EXTRA_VOL input volume -->
+	<path name="gain-volte_cp_wb_extra_vol-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 64 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 153 0 4 0 0 0 4 0 0 0 4 0 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 4 0 0 0 4 0 0 0 4 0 0 0 0 0 0 0 11 51 51 0 9 153 153 0 0 0 4 0 0 0 5 0 8 0 0 0 8 0 0 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 11 153 153 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 8 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 4 0 0 0 1 0 0 0 8 0 0 0 2 137 44 0 1 69 91" />
+		<param name="DSP3 XM f003:1" value="0 0 230 85 0 2 3 167 0 2 3 167 0 2 216 98 0 1 153 153 0 1 69 91 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 240 0 0 128 0 0 0 0 1 0 255 255 216 0 11 59 0 0 2 216 98 0 4 4 222 0 1 69 91 0 5 15 68 0 5 15 68 0 7 37 157 0 2 66 147 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 35 231 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-volte_cp_wb_extra_vol-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 5 85 85 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 6 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 160 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 4 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 0 0 0 0 8 0 0 0 14 0 0 0 0 0 8 0 0 0 8 0 14 172 0 0 15 51 64 0 8 202 0 0 11 59 0 0 10 252 128 0 10 65 0 0 8 202 0 0 0 0 0 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 16 0 0 0 0 0 0 0 14 51 51 0 8 0 0 0 7 0 0 0 6 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 16 0 0 0 2 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 137 44 0 2 0 0" />
+		<param name="DSP3 XM f003:1" value="0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 15 194 143 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 1 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 8 0 0 0 128 0 2 102 102 0 0 12 0 0 8 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 0 0 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 127 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 8 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 0 179 51 0 0 47 225 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 204 192 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 0 0 100 0 4 0 0 0 0 90 90" />
+	</path>
+
+	<!-- VoLTE VT CP WB input volume -->
+	<path name="gain-volte_vt_cp_wb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 64 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 153 0 4 0 0 0 4 0 0 0 4 0 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 4 0 0 0 4 0 0 0 4 0 0 0 0 0 0 0 11 51 51 0 9 153 153 0 0 0 4 0 0 0 5 0 8 0 0 0 8 0 0 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 11 153 153 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 8 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 4 0 0 0 1 0 0 0 8 0 0 0 2 137 44 0 1 69 91" />
+		<param name="DSP3 XM f003:1" value="0 0 230 85 0 2 3 167 0 2 3 167 0 2 216 98 0 1 153 153 0 1 69 91 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 240 0 0 128 0 0 0 0 1 0 255 255 216 0 11 59 0 0 2 216 98 0 4 4 222 0 1 69 91 0 5 15 68 0 5 15 68 0 7 37 157 0 2 66 147 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 35 231 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 5 85 85 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 6 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 160 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 4 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 0 0 0 0 8 0 0 0 14 0 0 0 0 0 8 0 0 0 8 0 14 172 0 0 15 51 64 0 8 202 0 0 11 59 0 0 10 252 128 0 10 65 0 0 8 202 0 0 0 0 0 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 16 0 0 0 0 0 0 0 14 51 51 0 8 0 0 0 7 0 0 0 6 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 16 0 0 0 2 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 137 44 0 2 0 0" />
+		<param name="DSP3 XM f003:1" value="0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 15 194 143 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 1 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 8 0 0 0 128 0 2 102 102 0 0 12 0 0 8 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 0 0 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 127 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 8 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 0 179 51 0 0 47 225 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 204 192 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 0 0 100 0 4 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-bt-sco-headset-in">
+		<ctl name="AIF2TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF2TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-volte_vt_cp_wb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- CP Call Input volume -->
+	<!-- call default volume -->
+	<path name="gain-incall_default-handset-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="128" />
+	</path>
+
+	<path name="gain-incall_default-speaker-mic">
+		<ctl name="IN3L Digital Volume" value="0" />
+	</path>
+
+	<path name="gain-incall_default-headset-mic">
+		<ctl name="IN2L Volume" value="27" />
+		<ctl name="IN2L Digital Volume" value="128" />
+	</path>
+
+	<path name="gain-incall_default-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+	</path>
+
+	<path name="gain-incall_default-bt-sco-headset-in">
+		<ctl name="AIF2TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF2TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_default-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- NB volume -->
+	<path name="gain-incall_nb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-incall_nb-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-incall_nb-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_nb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_nb-bt-sco-headset-in">
+		<ctl name="AIF2TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF2TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_nb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- NB/HANDOVER volume -->
+	<path name="gain-incall_nb_handover-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-incall_nb_handover-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-incall_nb_handover-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_nb_handover-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- NB/EXTRA_VOL volume -->
+	<path name="gain-incall_nb_extra_vol-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-incall_nb_extra_vol-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<!-- NB/EXTRA_VOL/HANDOVER volume -->
+	<path name="gain-incall_nb_extra_vol_handover-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 1 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 16 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 160 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 6 0 0 0 0 0 1 128 0 0 1 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 11 51 51 0 8 0 0 0 0 0 4 0 0 0 5 0 15 64 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 15 192 0 0 0 0 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 1 128 0 0 0 0 0 0 16 0 0 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 85 85 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 1 30 184 0 4 0 0 0 1 69 91 0 0 230 85" />
+		<param name="DSP3 XM f002:1" value="0 0 230 85 0 0 230 85 0 0 230 85 0 1 69 91 0 0 230 85 0 0 230 85 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 217 25 125 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 2 66 147 0 1 69 91 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 13 153 153 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 32 0 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<path name="gain-incall_nb_extra_vol_handover-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 1 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 2 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 24 0 8 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 32 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 0 122 225 0 1 0 0 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 1 51 51 0 2 102 102 0 2 102 102 0 1 51 51 0 1 51 51 0 1 51 51 0 0 0 0 0 4 0 0 0 13 0 0 0 0 0 6 0 0 0 6 0 10 0 0 0 10 0 0 0 10 102 102 0 11 0 0 0 11 0 0 0 12 0 0 0 12 0 0 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 14 215 10 0 8 0 0 0 7 51 51 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 12 0 0 0 3 0 0 0 6 102 102 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 3 167 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 0 182 246 0 0 182 246 0 0 182 246 0 0 182 246 0 0 230 85 0 0 230 85 0 15 198 167 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 0 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 5 0 0 0 32 0 2 102 102 0 0 12 0 0 9 0 0 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 15 0 85 215 41 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 137 44 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 5 15 68 0 5 15 68 0 2 3 167 0 2 3 167 0 0 230 85 0 2 137 44 0 2 3 167 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 198 167 0 15 235 133 0 15 198 167 0 15 198 167 0 0 179 51 0 0 45 51 0 4 0 0 0 0 0 100 0 16 0 0 0 255 255 241 0 0 250 0 0 0 143 192 0 6 89 0 0 12 53 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 8 0 0 0 16 0 0 0 16 0 0 0 4 0 0 0 16 0 0 0 4 0 0 0 0 0 1 0 0 0 0 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 16 0 0 0 0 0 0 0 0 165 165" />
+	</path>
+
+	<!-- WB volume -->
+	<path name="gain-incall_wb-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 64 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 153 0 4 0 0 0 4 0 0 0 4 0 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 4 0 0 0 4 0 0 0 4 0 0 0 0 0 0 0 11 51 51 0 9 153 153 0 0 0 4 0 0 0 5 0 8 0 0 0 8 0 0 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 11 153 153 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 8 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 4 0 0 0 1 0 0 0 8 0 0 0 2 137 44 0 1 69 91" />
+		<param name="DSP3 XM f003:1" value="0 0 230 85 0 2 3 167 0 2 3 167 0 2 216 98 0 1 153 153 0 1 69 91 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 240 0 0 128 0 0 0 0 1 0 255 255 216 0 11 59 0 0 2 216 98 0 4 4 222 0 1 69 91 0 5 15 68 0 5 15 68 0 7 37 157 0 2 66 147 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 35 231 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-incall_wb-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 5 85 85 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 6 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 160 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 4 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 0 0 0 0 8 0 0 0 14 0 0 0 0 0 8 0 0 0 8 0 14 172 0 0 15 51 64 0 8 202 0 0 11 59 0 0 10 252 128 0 10 65 0 0 8 202 0 0 0 0 0 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 16 0 0 0 0 0 0 0 14 51 51 0 8 0 0 0 7 0 0 0 6 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 16 0 0 0 2 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 137 44 0 2 0 0" />
+		<param name="DSP3 XM f003:1" value="0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 15 194 143 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 1 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 8 0 0 0 128 0 2 102 102 0 0 12 0 0 8 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 0 0 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 127 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 8 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 0 179 51 0 0 47 225 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 204 192 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 0 0 100 0 4 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-incall_wb-headset-mic">
+		<ctl name="IN2L Volume" value="21" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_wb-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_wb-bt-sco-headset-in">
+		<ctl name="AIF2TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF2TX2 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-incall_wb-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- WB/EXTRA_VOL volume -->
+	<path name="gain-incall_wb_extra_vol-handset-mic">
+		<ctl name="IN1L Digital Volume" value="136" />
+		<ctl name="IN3L Digital Volume" value="136" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 0 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 64 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 254 192 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 153 0 4 0 0 0 4 0 0 0 4 0 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 4 0 0 0 4 0 0 0 4 0 0 0 0 0 0 0 11 51 51 0 9 153 153 0 0 0 4 0 0 0 5 0 8 0 0 0 8 0 0 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 14 102 102 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 11 153 153 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 8 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 4 0 0 0 1 0 0 0 8 0 0 0 2 137 44 0 1 69 91" />
+		<param name="DSP3 XM f003:1" value="0 0 230 85 0 2 3 167 0 2 3 167 0 2 216 98 0 1 153 153 0 1 69 91 0 15 133 30 0 1 153 154 0 0 0 16 0 1 0 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16 0 0 12 0 0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 1 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 64 0 0 0 16 0 0 4 0 0 0 1 153 154 0 2 238 0 0 9 153 153 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 66 147 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 240 0 0 128 0 0 0 0 1 0 255 255 216 0 11 59 0 0 2 216 98 0 4 4 222 0 1 69 91 0 5 15 68 0 5 15 68 0 7 37 157 0 2 66 147 0 2 66 147 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 15 133 30 0 0 179 51 0 0 35 231 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 20 160 0 0 20 160 0 0 20 160 0 0 5 32 0 0 25 192 0 16 0 0 0 1 179 64 0 16 0 0 0 16 0 0 0 0 0 0 0 0 90 90" />
+	</path>
+
+	<path name="gain-incall_wb_extra_vol-speaker-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="IN3L Digital Volume" value="140" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+		<param name="DSP3 XM f003:0" value="0 0 0 1 0 0 2 71 0 0 0 0 0 0 0 1 0 0 0 160 0 0 0 160 0 0 2 0 0 0 0 1 0 0 0 2 0 0 0 2 0 0 0 0 0 0 2 0 0 0 0 3 0 0 0 242 0 0 0 240 0 4 0 0 0 4 0 0 0 4 0 0 0 15 98 57 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 5 85 85 0 0 0 64 0 0 0 64 0 0 64 0 0 0 64 0 0 6 0 0 0 0 0 1 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 254 160 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 255 0 0 0 0 32 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 64 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 4 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 12 204 192 0 0 0 0 0 8 0 0 0 14 0 0 0 0 0 8 0 0 0 8 0 14 172 0 0 15 51 64 0 8 202 0 0 11 59 0 0 10 252 128 0 10 65 0 0 8 202 0 0 0 0 0 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 3 51 64 0 16 0 0 0 0 0 0 0 14 51 51 0 8 0 0 0 7 0 0 0 6 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 0 0 48 0 16 0 0 0 2 0 0 0 4 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 8 0 0 0 2 137 44 0 2 0 0" />
+		<param name="DSP3 XM f003:1" value="0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 2 0 0 0 15 194 143 0 2 102 102 0 0 0 16 0 1 0 0 0 0 0 1 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 8 0 0 0 128 0 2 102 102 0 0 12 0 0 8 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 102 102 0 0 0 2 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 26 0 169 121 48 0 3 0 0 0 0 16 0 0 0 64 0 0 5 0 0 0 1 153 154 0 2 238 0 0 9 196 0 0 12 0 0 0 13 153 153 0 13 0 0 0 2 64 0 0 2 0 0 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 127 0 1 0 0 0 0 0 0 0 255 255 216 0 11 59 0 0 8 255 89 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 2 137 44 0 8 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 12 0 0 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 15 194 143 0 0 179 51 0 0 47 225 0 4 0 0 0 0 0 40 0 16 0 0 0 255 255 241 0 0 187 128 0 0 143 192 0 6 89 0 0 13 47 0 0 12 53 0 0 2 238 0 0 0 1 64 0 12 204 192 0 255 255 239 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 16 0 0 0 0 0 1 0 0 204 192 0 0 204 192 0 0 102 96 0 0 51 64 0 0 102 96 0 16 0 0 0 1 179 64 0 0 0 0 0 0 0 100 0 4 0 0 0 0 90 90" />
+	</path>
+
+	<!-- Loopback Input (no delay) -->
+	<path name="gain-loopback-mic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="26" />
+	</path>
+
+	<path name="gain-loopback-2nd-mic">
+		<ctl name="IN3L Digital Volume" value="120" />
+		<ctl name="LHPF2 Input 1 Volume" value="26" />
+	</path>
+
+	<!-- Packet Loopback Input -->
+	<path name="gain-loopback_packet-mic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="26" />
+	</path>
+
+	<path name="gain-loopback_packet-2nd-mic">
+		<ctl name="IN3L Digital Volume" value="120" />
+		<ctl name="LHPF2 Input 1 Volume" value="26" />
+	</path>
+
+	<path name="gain-loopback_packet-3rd-mic">
+		<ctl name="IN4R Digital Volume" value="120" />
+		<ctl name="LHPF2 Input 1 Volume" value="26" />
+	</path>
+
+	<path name="gain-loopback_packet-headset-mic">
+		<ctl name="IN2L Volume" value="25" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-loopback_packet-handset-dualmic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="26" />
+		<param name="DSP3 XM f002:0" value="0 0 0 0 0 0 0 71 0 0 0 2 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 3 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 5 85 85 0 8 0 0 0 0 0 64 0 0 0 64 0 1 0 0 0 1 0 0 0 12 0 0 0 0 0 0 0 12 0 0 0 0 0 11 0 0 0 64 0 8 0 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 255 0 0 0 0 64 0 0 0 0 0 0 0 0 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 153 0 4 0 0 0 4 0 0 0 4 0 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 1 192 0 0 4 0 0 0 4 0 0 0 4 0 0 0 0 0 0 0 11 51 51 0 9 153 153 0 0 0 4 0 0 0 5 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 8 0 0 0 14 102 102 0 14 102 102 0 0 0 0 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 1 153 153 0 0 0 0 0 11 153 153 0 4 0 0 0 3 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 8 0 0 0 2 0 0 0 0 0 48 0 16 0 0 0 3 85 85 0 8 0 0 0 8 0 0 0 1 0 0 0 0 32 0 0 1 2 112 0 1 2 112 0 0 64 0 0 0 128 0 0 15 186 94 0 1 153 154 0 0 0 16 0 0 128 0 0 0 0 0 0 1 64 0 0 0 41 95 0 6 0 0 0 0 0 0 0 0 0 100 0 1 174 16" />
+		<param name="DSP3 XM f002:1" value="0 14 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 68 68 0 0 68 68 0 0 68 68 0 0 68 68 0 0 68 68 0 0 68 68 0 0 0 2 0 3 51 51 0 0 224 0 0 0 4 76 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 14 0 234 114 88 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 51 51 0 0 160 0 0 0 64 0 0 0 128 0 0 2 64 0 0 0 40 246 0 0 0 3 0 0 0 65 0 4 0 0 0 0 0 126 0 0 128 0 0 0 0 0 0 255 255 216 0 11 59 0 0 1 2 112 0 16 0 0 0 15 186 94 0 0 179 51 0 0 35 231 0 16 0 0 0 0 10 90" />
+	</path>
+
+	<path name="gain-loopback_packet-speaker-dualmic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="26" />
+		<param name="DSP3 XM f002:0" value="0 0 0 1 0 0 0 71 0 0 0 2 0 0 0 0 0 0 0 80 0 0 0 80 0 0 1 0 0 0 0 1 0 0 0 3 0 0 0 2 0 0 0 0 0 0 1 0 0 0 0 3 0 0 0 122 0 0 0 120 0 4 0 0 0 4 0 0 0 4 0 0 0 4 0 0 0 14 202 78 0 8 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 8 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 6 56 227 0 8 0 0 0 0 0 32 0 0 0 80 0 0 96 0 0 0 96 0 0 1 0 0 0 0 0 0 0 8 0 0 0 0 0 9 0 0 0 96 0 0 64 0 0 16 0 0 0 0 0 1 0 0 0 8 0 0 0 16 0 8 0 0 0 255 0 0 0 0 64 0 0 0 0 0 0 0 0 0 0 0 0 5 0 16 0 0 0 0 0 5 0 0 0 0 0 1 153 153 0 1 0 0 0 1 153 154 0 1 153 154 0 1 153 154 0 1 153 154 0 1 153 154 0 1 153 154 0 1 153 154 0 12 0 0 0 12 0 0 0 12 0 0 0 15 153 153 0 4 0 0 0 6 0 0 0 0 0 0 0 8 0 0 0 9 153 153 0 0 0 6 0 0 0 6 0 15 235 133 0 14 102 102 0 13 153 153 0 14 102 102 0 15 215 10 0 16 0 0 0 16 0 0 0 0 0 0 0 9 153 153 0 9 153 153 0 8 0 0 0 8 0 0 0 12 0 0 0 16 0 0 0 16 0 0 0 0 0 0 0 6 102 102 0 9 153 153 0 8 0 0 0 6 102 102 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 8 0 8 0 0 0 2 0 0 0 0 0 48 0 10 0 0 0 1 153 153 0 8 0 0 0 8 0 0 0 1 0 0 0 0 32 0 0 0 230 85 0 0 230 85 0 0 32 0 0 1 0 0 0 15 202 192 0 2 102 102 0 0 0 16 0 0 128 0 0 0 0 2 0 0 128 0 0 0 41 95 0 4 0 0 0 0 0 19 0 0 0 32 0 1 153 153" />
+		<param name="DSP3 XM f002:1" value="0 10 79 103 0 4 0 0 0 4 0 0 0 0 16 0 0 15 128 0 0 6 0 0 0 15 246 0 0 1 208 0 0 3 0 0 0 5 64 0 0 13 192 0 0 0 0 0 0 0 0 0 0 0 68 68 0 0 68 68 0 0 68 68 0 0 68 68 0 0 68 68 0 0 68 68 0 0 0 1 0 0 248 0 0 8 102 96 0 0 1 128 0 0 51 64 0 0 0 37 0 0 0 0 0 0 0 0 0 0 0 14 0 234 114 88 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 15 0 97 197 234 0 0 0 0 0 0 0 0 0 4 0 0 0 0 1 0 0 0 64 0 0 0 128 0 0 2 64 0 0 0 40 246 0 0 0 3 0 0 0 65 0 9 0 0 0 0 0 126 0 0 128 0 0 0 0 0 0 255 255 216 0 11 59 0 0 1 153 154 0 12 204 205 0 15 202 192 0 0 179 51 0 0 50 183 0 8 0 0 0 0 10 90" />
+	</path>
+
+	<!-- TTY Mode Input volume -->
+	<path name="gain-tty_mode-vco-mic">
+		<ctl name="IN1L Digital Volume" value="140" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-tty_mode-full-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-tty_mode-hco-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- call forwarding input volume -->
+	<path name="gain-call_forwarding_master-mic">
+		<!-- we use default volume -->
+	</path>
+
+	<path name="gain-call_forwarding_slave-handset-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-speaker-mic">
+		<ctl name="IN3L Digital Volume" value="128" />
+		<ctl name="LHPF2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-headset-mic">
+		<ctl name="IN2L Volume" value="30" />
+		<ctl name="IN2L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-headphone-mic">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-bt-sco-headset-in">
+		<ctl name="AIF1TX1 Input 1 Volume" value="32" />
+		<ctl name="AIF1TX2 Input 1 Volume" value="32" />
+	</path>
+
+	<path name="gain-call_forwarding_slave-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="LHPF1 Input 1 Volume" value="32" />
+	</path>
+
+	<!-- remote mic input volume -->
+	<path name="gain-remote-bt-ble-headset-in">
+		<ctl name="IN1L Digital Volume" value="128" />
+		<ctl name="AIF3TX1 Input 2 Volume" value="32" />
+		<ctl name="AIF3TX2 Input 2 Volume" value="32" />
+	</path>
+
+
+	<!-- echo(rms) test input volume -->
+	<path name="gain-echo_test-mic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="26" />
+	</path>
+
+	<path name="gain-echo_test-2nd-mic">
+		<ctl name="IN3L Digital Volume" value="120" />
+		<ctl name="LHPF2 Input 1 Volume" value="26" />
+	</path>
+
+	<path name="gain-echo_test-3rd-mic">
+		<ctl name="IN4R Digital Volume" value="120" />
+		<ctl name="LHPF2 Input 1 Volume" value="26" />
+	</path>
+
+	<path name="gain-echo_test-dualmic">
+		<ctl name="IN1L Digital Volume" value="120" />
+		<ctl name="LHPF1 Input 1 Volume" value="20" />
+		<ctl name="IN3L Digital Volume" value="120" />
+		<ctl name="LHPF2 Input 1 Volume" value="20" />
+	</path>
+
+    <!--
+    #######################################################
+    ### AUDIO ROUTING
+    #######################################################
+    -->
+
+    <path name="none">
+        <!-- Empty path -->
+    </path>
+
+    <!-- ########## Playback ########## -->
+
+    <path name="earpiece">
+        <path name="media-handset" />
+		<path name="gain-media-handset" />
+    </path>
+
+    <path name="speaker">
+        <path name="media-speaker" />
+		<path name="gain-media-speaker" />
+    </path>
+
+    <path name="headphones">
+        <path name="media-headset" />
+		<path name="gain-media-headset" />
+    </path>
+
+    <path name="speaker-and-headphones">
+        <path name="media-speaker-headset" />
+    	<path name="gain-media-speaker-headset" />
+    </path>
+
+    <path name="voice-earpiece">
+        <path name="incall_nb-handset" />
+    	<path name="gain-incall_nb-handset" />
+    </path>
+
+    <path name="voice-earpiece-wb">
+        <path name="incall_wb-handset" />
+    	<path name="gain-incall_wb-handset" />
+    </path>
+
+    <path name="voice-speaker">
+    	<path name="incall_nb-speaker" />
+    	<path name="gain-incall_nb-speaker" />
+    </path>
+
+    <path name="voice-speaker-wb">
+        <path name="incall_wb-speaker" />
+    	<path name="gain-incall_wb-speaker" />
+    </path>
+
+    <path name="voice-headphones">
+        <path name="incall_nb-headphone" />
+    	<path name="gain-incall_nb-headphone" />
+    </path>
+
+    <path name="voice-headphones-wb">
+        <path name="incall_wb-headphone" />
+    	<path name="gain-incall_wb-headphone" />
+    </path>
+
+    <path name="voice-bt-sco-headset">
+        <path name="incall_nb-bt-sco-headset" />
+    	<path name="gain-incall_nb-bt-sco-headset" />
+    </path>
+
+    <path name="voice-bt-sco-headset-wb">
+        <path name="incall_wb-bt-sco-headset" />
+    	<path name="gain-incall_wb-bt-sco-headset" />
+    </path>
+
+    <path name="hdmi">
+        <!-- TODO -->
+    </path>
+
+    <path name="speaker-and-hdmi">
+        <!-- TODO -->
+    </path>
+
+    <path name="bt-sco-headset">
+        <path name="media-bt-sco-headset" />
+    	<path name="gain-media-bt-sco-headset" />
+    </path>
+
+    <!-- ########## Capture ########## -->
+
+    <path name="earpiece-mic">
+        <path name="media-mic" />
+    	<path name="gain-media-mic" />
+    </path>
+
+    <path name="speaker-mic">
+        <path name="media-mic" />
+    	<path name="gain-media-mic" />
+    </path>
+
+    <path name="voice-mic">
+        <path name="incall_nb-handset-mic" />
+    	<path name="gain-incall_nb-handset-mic" />
+    </path>
+
+    <!-- Two mic -->
+    <path name="voice-earpiece-mic">
+        <path name="incall_nb-handset-mic" />
+    	<path name="gain-incall_nb-handset-mic" />
+    </path>
+
+    <path name="voice-earpiece-mic-wb">
+        <path name="incall_wb-handset-mic" />
+    	<path name="gain-incall_wb-handset-mic" />
+    </path>
+
+    <path name="voice-speaker-mic">
+        <path name="incall_nb-speaker-mic" />
+    	<path name="gain-incall_nb-speaker-mic" />
+    </path>
+
+    <path name="voice-speaker-mic-wb">
+        <path name="incall_wb-speaker-mic" />
+    	<path name="gain-incall_wb-speaker-mic" />
+    </path>
+
+    <path name="voice-headset-mic">
+        <path name="incall_nb-headset-mic" />
+    	<path name="gain-incall_nb-headset-mic" />
+    </path>
+
+    <path name="voice-headset-mic-wb">
+        <path name="incall_wb-headset-mic" />
+    	<path name="gain-incall_wb-headset-mic" />
+    </path>
+
+    <path name="voice-bt-sco-mic">
+        <path name="incall_nb-bt-sco-headset-in" />
+    	<path name="gain-incall_nb-bt-sco-headset-in" />
+    </path>
+
+    <path name="voice-bt-sco-mic-wb">
+        <path name="incall_wb-bt-sco-headset-in" />
+    	<path name="gain-incall_wb-bt-sco-headset-in" />
+    </path>
+
+    <path name="hdmi-mic">
+        <!-- TODO -->
+    </path>
+
+    <path name="bt-sco-mic">
+        <path name="media-bt-sco-headset-in" />
+    	<path name="gain-media-bt-sco-headset-in" />
+    </path>
+
+    <path name="voice-rec-headset-mic">
+        <path name="recording-headset-mic" />
+    	<path name="gain-recording-headset-mic" />
+    </path>
+
+    <path name="voice-rec-mic">
+        <path name="recording-mic" />
+    	<path name="gain-recording-mic" />
+    </path>
+
+	<!-- samsung uses the same path
+    <path name="camcorder-mic">
+    </path>
+	-->
+
+    <path name="loopback-aec">
+        <!-- Empty path -->
+    </path>
+
+</mixer>

--- a/device.mk
+++ b/device.mk
@@ -22,6 +22,9 @@ DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 # Audio
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/audio/mixer_paths_0.xml:system/etc/mixer_paths_0.xml
+    
+## (2) Also get non-open-source specific aspects if available
+$(call inherit-product-if-exists, vendor/samsung/zerofltexx/zerofltexx-vendor.mk)
 
 # Carrier init
 PRODUCT_PACKAGES += \

--- a/device.mk
+++ b/device.mk
@@ -19,6 +19,10 @@ LOCAL_PATH := device/samsung/zerofltexx
 ## device overlays
 DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 
+# Audio
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/configs/audio/mixer_paths_0.xml:system/etc/mixer_paths_0.xml
+
 # Carrier init
 PRODUCT_PACKAGES += \
     init.carrier.rc


### PR DESCRIPTION
Hallo,

first of all, thank you very much for your work!

Yesterday I tried to flash the current build on my device SM-G920F following this [description](https://wiki.lineageos.org/devices/zerofltexx).

It is already mentioned there that the instructions only work with the bootloader version G920FXXU5EQI8. My device has the bootloader version G920FXXS5ERA7. How can I switch to the older bootloader or will there soon be a way to flash lineageos on devices having different bootloader versions.

Thank you and best wishes,
pinplex